### PR TITLE
Undate Modbus.java

### DIFF
--- a/modbus-codec/src/main/java/com/digitalpetri/modbus/codec/Modbus.java
+++ b/modbus-codec/src/main/java/com/digitalpetri/modbus/codec/Modbus.java
@@ -57,7 +57,7 @@ public abstract class Modbus {
     /** Shutdown/stop any shared resources that may be in use. */
     public static void releaseSharedResources() {
         sharedExecutor().shutdown();
-        sharedEventLoop().shutdownGracefully();
+        sharedEventLoop().shutdownGracefully().get();
         sharedWheelTimer().stop();
     }
 


### PR DESCRIPTION
Wait until EventLoop shutdown completely when releasing shared resources. #11 