### PR TITLE
Automatic JPMS module names

### DIFF
--- a/modbus-codec/pom.xml
+++ b/modbus-codec/pom.xml
@@ -26,6 +26,10 @@
 
     <artifactId>modbus-codec</artifactId>
 
+    <properties>
+        <javaModuleName>com.digitalpetri.modbus.codec</javaModuleName>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.digitalpetri.modbus</groupId>

--- a/modbus-core/pom.xml
+++ b/modbus-core/pom.xml
@@ -26,6 +26,10 @@
 
     <artifactId>modbus-core</artifactId>
 
+    <properties>
+        <javaModuleName>com.digitalpetri.modbus.core</javaModuleName>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/modbus-examples/pom.xml
+++ b/modbus-examples/pom.xml
@@ -26,6 +26,10 @@
 
     <artifactId>modbus-examples</artifactId>
 
+    <properties>
+        <javaModuleName>com.digitalpetri.modbus.examples</javaModuleName>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.digitalpetri.modbus</groupId>

--- a/modbus-master-tcp/pom.xml
+++ b/modbus-master-tcp/pom.xml
@@ -26,6 +26,10 @@
 
     <artifactId>modbus-master-tcp</artifactId>
 
+    <properties>
+        <javaModuleName>com.digitalpetri.modbus.master.tcp</javaModuleName>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.digitalpetri.modbus</groupId>

--- a/modbus-slave-tcp/pom.xml
+++ b/modbus-slave-tcp/pom.xml
@@ -26,6 +26,10 @@
 
     <artifactId>modbus-slave-tcp</artifactId>
 
+    <properties>
+        <javaModuleName>com.digitalpetri.modbus.slave.tcp</javaModuleName>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.digitalpetri.modbus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <metrics.version>3.1.2</metrics.version>
-        <netty.version>4.1.48.Final</netty.version>
-        <slf4j.version>1.7.16</slf4j.version>
-        <testng.version>6.9.10</testng.version>
+        <metrics.version>4.2.7</metrics.version>
+        <netty.version>4.1.72.Final</netty.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <testng.version>7.5</testng.version>
     </properties>
 
     <profiles>
@@ -76,7 +76,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -89,7 +89,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -123,7 +123,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.5</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -132,9 +132,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
                 <executions>
                     <execution>
@@ -149,12 +150,12 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.5.3</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -166,7 +167,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.3</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,26 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.1</version>
+                    <executions>
+                        <execution>
+                            <id>default-jar</id>
+                            <configuration>
+                                <archive>
+                                    <manifest>
+                                        <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    </manifest>
+                                    <manifestEntries>
+                                        <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                                    </manifestEntries>
+                                    <index>true</index>
+                                </archive>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>3.0.5</version>
@@ -146,7 +166,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>


### PR DESCRIPTION
I also tried to implement [module-info.java](https://github.com/hurelhuyag/modbus/tree/jpms-module-info) file. But it is [tricky](https://stackoverflow.com/questions/62442674/how-to-use-maven-with-both-jigsaw-and-jre-8-support) to support jre8 with module-info.class files. I think currently it is a better approach.