### PR TITLE
Bootstrap and pipeline customizers in Netty server transports

### DIFF
--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyRtuServerTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyRtuServerTransport.java
@@ -72,6 +72,8 @@ public class NettyRtuServerTransport implements ModbusRtuServerTransport {
                     }
                   })
                   .addLast(new ModbusRtuServerFrameReceiver());
+
+              config.pipelineCustomizer().accept(ch.pipeline());
             } else {
               ch.close();
             }
@@ -81,6 +83,8 @@ public class NettyRtuServerTransport implements ModbusRtuServerTransport {
     bootstrap.group(config.eventLoopGroup());
     bootstrap.option(ChannelOption.SO_REUSEADDR, Boolean.TRUE);
     bootstrap.childOption(ChannelOption.TCP_NODELAY, Boolean.TRUE);
+
+    config.bootstrapCustomizer().accept(bootstrap);
 
     bootstrap.bind(config.bindAddress(), config.port())
         .addListener((ChannelFutureListener) channelFuture -> {

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyServerTransportConfig.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyServerTransportConfig.java
@@ -2,6 +2,8 @@ package com.digitalpetri.modbus.server;
 
 import com.digitalpetri.modbus.Modbus;
 import com.digitalpetri.modbus.Netty;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
@@ -13,12 +15,18 @@ import java.util.function.Consumer;
  * @param port the port to bind to.
  * @param eventLoopGroup the {@link EventLoopGroup} to use.
  * @param executor the {@link ExecutorService} to use.
+ * @param bootstrapCustomizer a {@link Consumer} that can be used to customize the Netty
+ *     {@link ServerBootstrap}.
+ * @param pipelineCustomizer a {@link Consumer} that can be used to customize the Netty
+ *     {@link ChannelPipeline}.
  */
 public record NettyServerTransportConfig(
     String bindAddress,
     int port,
     EventLoopGroup eventLoopGroup,
-    ExecutorService executor
+    ExecutorService executor,
+    Consumer<ServerBootstrap> bootstrapCustomizer,
+    Consumer<ChannelPipeline> pipelineCustomizer
 ) {
 
   /**
@@ -56,6 +64,16 @@ public record NettyServerTransportConfig(
      */
     public ExecutorService executor;
 
+    /**
+     * A {@link Consumer} that can be used to customize the Netty {@link ServerBootstrap}.
+     */
+    public Consumer<ServerBootstrap> bootstrapCustomizer = b -> {};
+
+    /**
+     * A {@link Consumer} that can be used to customize the Netty {@link ChannelPipeline}.
+     */
+    public Consumer<ChannelPipeline> pipelineCustomizer = p -> {};
+
     public NettyServerTransportConfig build() {
       if (eventLoopGroup == null) {
         eventLoopGroup = Netty.sharedEventLoop();
@@ -68,7 +86,9 @@ public record NettyServerTransportConfig(
           bindAddress,
           port,
           eventLoopGroup,
-          executor
+          executor,
+          bootstrapCustomizer,
+          pipelineCustomizer
       );
     }
   }

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyTcpServerTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyTcpServerTransport.java
@@ -73,12 +73,16 @@ public class NettyTcpServerTransport implements ModbusTcpServerTransport {
                 })
                 .addLast(new ModbusTcpCodec())
                 .addLast(new ModbusTcpFrameHandler());
+
+            config.pipelineCustomizer().accept(ch.pipeline());
           }
         });
 
     bootstrap.group(config.eventLoopGroup());
     bootstrap.option(ChannelOption.SO_REUSEADDR, Boolean.TRUE);
     bootstrap.childOption(ChannelOption.TCP_NODELAY, Boolean.TRUE);
+
+    config.bootstrapCustomizer().accept(bootstrap);
 
     bootstrap.bind(config.bindAddress(), config.port())
         .addListener((ChannelFutureListener) channelFuture -> {


### PR DESCRIPTION
Allow the Netty `ServerBootstrap` and `ChannelPipeline` to be customized in Netty-based server transports.