### PR TITLE
Connection status listener for NettyTcpClientTransport

### DIFF
--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTcpClientTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTcpClientTransport.java
@@ -223,7 +223,7 @@ public class NettyTcpClientTransport implements ModbusTcpClientTransport {
     /**
      * Callback invoked when the transport has disconnected.
      *
-     * <p> Note that implementations do not need to initiate a reconnect, as this is handled
+     * <p>Note that implementations do not need to initiate a reconnect, as this is handled
      * automatically by {@link NettyTcpClientTransport}.
      */
     void onConnectionLost();

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTcpClientTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTcpClientTransport.java
@@ -222,6 +222,9 @@ public class NettyTcpClientTransport implements ModbusTcpClientTransport {
 
     /**
      * Callback invoked when the transport has disconnected.
+     *
+     * <p> Note that implementations do not need to initiate a reconnect, as this is handled
+     * automatically by {@link NettyTcpClientTransport}.
      */
     void onConnectionLost();
 

--- a/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusTcpClientServerIT.java
+++ b/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusTcpClientServerIT.java
@@ -136,6 +136,8 @@ public class ModbusTcpClientServerIT extends ClientServerIT {
       }
     });
 
+    assertTrue(client.isConnected());
+
     client.disconnect();
     assertTrue(onConnectionLost.await(1, TimeUnit.SECONDS));
 


### PR DESCRIPTION
Adds the ability to register a `ConnectionListener` with `NettyTcpClientTransport` that is notified when the connection is established or lost.