### PR TITLE
Move Netty and ModbusTcpCodec into package "tcp" to fix split packages

### DIFF
--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/client/NettyClientTransportConfig.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/client/NettyClientTransportConfig.java
@@ -1,7 +1,7 @@
 package com.digitalpetri.modbus.client;
 
 import com.digitalpetri.modbus.Modbus;
-import com.digitalpetri.modbus.Netty;
+import com.digitalpetri.modbus.tcp.Netty;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/client/NettyTcpClientTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/client/NettyTcpClientTransport.java
@@ -1,7 +1,7 @@
 package com.digitalpetri.modbus.client;
 
 import com.digitalpetri.fsm.FsmContext;
-import com.digitalpetri.modbus.ModbusTcpCodec;
+import com.digitalpetri.modbus.tcp.ModbusTcpCodec;
 import com.digitalpetri.modbus.ModbusTcpFrame;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;
 import com.digitalpetri.netty.fsm.ChannelActions;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyServerTransportConfig.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyServerTransportConfig.java
@@ -1,7 +1,7 @@
 package com.digitalpetri.modbus.server;
 
 import com.digitalpetri.modbus.Modbus;
-import com.digitalpetri.modbus.Netty;
+import com.digitalpetri.modbus.tcp.Netty;
 import io.netty.channel.EventLoopGroup;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyTcpServerTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/server/NettyTcpServerTransport.java
@@ -1,6 +1,6 @@
 package com.digitalpetri.modbus.server;
 
-import com.digitalpetri.modbus.ModbusTcpCodec;
+import com.digitalpetri.modbus.tcp.ModbusTcpCodec;
 import com.digitalpetri.modbus.ModbusTcpFrame;
 import com.digitalpetri.modbus.exceptions.UnknownUnitIdException;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/ModbusTcpCodec.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/ModbusTcpCodec.java
@@ -1,5 +1,7 @@
-package com.digitalpetri.modbus;
+package com.digitalpetri.modbus.tcp;
 
+import com.digitalpetri.modbus.MbapHeader;
+import com.digitalpetri.modbus.ModbusTcpFrame;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageCodec;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/Netty.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/Netty.java
@@ -1,4 +1,4 @@
-package com.digitalpetri.modbus;
+package com.digitalpetri.modbus.tcp;
 
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;

--- a/modbus-tcp/src/test/java/com/digitalpetri/modbus/ModbusTcpCodecTest.java
+++ b/modbus-tcp/src/test/java/com/digitalpetri/modbus/ModbusTcpCodecTest.java
@@ -2,6 +2,7 @@ package com.digitalpetri.modbus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.digitalpetri.modbus.tcp.ModbusTcpCodec;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.embedded.EmbeddedChannel;

--- a/modbus-tests/src/test/java/modbus/ModbusTcpClientServerIT.java
+++ b/modbus-tests/src/test/java/modbus/ModbusTcpClientServerIT.java
@@ -1,7 +1,7 @@
 package modbus;
 
 import com.digitalpetri.modbus.ModbusPduSerializer.DefaultRequestSerializer;
-import com.digitalpetri.modbus.Netty;
+import com.digitalpetri.modbus.tcp.Netty;
 import com.digitalpetri.modbus.client.ModbusClient;
 import com.digitalpetri.modbus.client.ModbusTcpClient;
 import com.digitalpetri.modbus.client.NettyTcpClientTransport;


### PR DESCRIPTION
Regarding the issue #82 I made a quick PR. I'm not sure if you are open to moving the two classes but if so this is a quick fix.