### PR TITLE
Use distinct Java packages for each Maven module

### DIFF
--- a/modbus-serial/pom.xml
+++ b/modbus-serial/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>modbus-serial</artifactId>
 
   <properties>
+    <javaModuleName>com.digitalpetri.modbus.serial</javaModuleName>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/SerialPortTransportConfig.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/SerialPortTransportConfig.java
@@ -1,6 +1,7 @@
-package com.digitalpetri.modbus;
+package com.digitalpetri.modbus.serial;
 
-import com.digitalpetri.modbus.client.SerialPortClientTransport;
+import com.digitalpetri.modbus.Modbus;
+import com.digitalpetri.modbus.serial.client.SerialPortClientTransport;
 import com.fazecast.jSerialComm.SerialPort;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
@@ -1,13 +1,12 @@
-package com.digitalpetri.modbus.server;
+package com.digitalpetri.modbus.serial.client;
 
 import com.digitalpetri.modbus.ModbusRtuFrame;
-import com.digitalpetri.modbus.ModbusRtuRequestFrameParser;
-import com.digitalpetri.modbus.ModbusRtuRequestFrameParser.Accumulated;
-import com.digitalpetri.modbus.ModbusRtuRequestFrameParser.ParserState;
-import com.digitalpetri.modbus.SerialPortTransportConfig;
-import com.digitalpetri.modbus.SerialPortTransportConfig.Builder;
-import com.digitalpetri.modbus.exceptions.UnknownUnitIdException;
+import com.digitalpetri.modbus.ModbusRtuResponseFrameParser;
+import com.digitalpetri.modbus.ModbusRtuResponseFrameParser.Accumulated;
+import com.digitalpetri.modbus.ModbusRtuResponseFrameParser.ParserState;
+import com.digitalpetri.modbus.client.ModbusRtuClientTransport;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;
+import com.digitalpetri.modbus.serial.SerialPortTransportConfig;
 import com.fazecast.jSerialComm.SerialPort;
 import com.fazecast.jSerialComm.SerialPortDataListener;
 import com.fazecast.jSerialComm.SerialPortEvent;
@@ -16,20 +15,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Modbus RTU/Serial server transport; a {@link ModbusRtuServerTransport} that sends and receives
+ * Modbus RTU/Serial client transport; a {@link ModbusRtuClientTransport} that sends and receives
  * {@link ModbusRtuFrame}s over a serial port.
  */
-public class SerialPortServerTransport implements ModbusRtuServerTransport {
+public class SerialPortClientTransport implements ModbusRtuClientTransport {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-  private final ModbusRtuRequestFrameParser frameParser = new ModbusRtuRequestFrameParser();
-  private final AtomicReference<FrameReceiver<ModbusRtuRequestContext, ModbusRtuFrame>>
-      frameReceiver = new AtomicReference<>();
+  private final ModbusRtuResponseFrameParser frameParser = new ModbusRtuResponseFrameParser();
+  private final AtomicReference<Consumer<ModbusRtuFrame>> frameReceiver = new AtomicReference<>();
 
   private final ExecutionQueue executionQueue;
 
@@ -37,7 +31,7 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
 
   private final SerialPortTransportConfig config;
 
-  public SerialPortServerTransport(SerialPortTransportConfig config) {
+  public SerialPortClientTransport(SerialPortTransportConfig config) {
     this.config = config;
 
     serialPort = SerialPort.getCommPort(config.serialPort());
@@ -54,13 +48,14 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
   }
 
   @Override
-  public CompletionStage<Void> bind() {
+  public synchronized CompletableFuture<Void> connect() {
     if (serialPort.isOpen()) {
       return CompletableFuture.completedFuture(null);
     } else {
       if (serialPort.openPort()) {
         frameParser.reset();
 
+        // note: no-op if already added from previous connect()
         serialPort.addDataListener(new ModbusRtuDataListener());
 
         return CompletableFuture.completedFuture(null);
@@ -75,7 +70,7 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
   }
 
   @Override
-  public CompletionStage<Void> unbind() {
+  public synchronized CompletableFuture<Void> disconnect() {
     if (serialPort.isOpen()) {
       if (serialPort.closePort()) {
         frameParser.reset();
@@ -94,8 +89,49 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
   }
 
   @Override
-  public void receive(FrameReceiver<ModbusRtuRequestContext, ModbusRtuFrame> frameReceiver) {
+  public boolean isConnected() {
+    return serialPort.isOpen();
+  }
+
+  @Override
+  public CompletionStage<Void> send(ModbusRtuFrame frame) {
+    ByteBuffer buffer = ByteBuffer.allocate(256);
+
+    try {
+      buffer.put((byte) frame.unitId());
+      buffer.put(frame.pdu());
+      buffer.put(frame.crc());
+
+      byte[] data = new byte[buffer.position()];
+      buffer.flip();
+      buffer.get(data);
+
+      int totalWritten = 0;
+      while (totalWritten < data.length) {
+        int written = serialPort.writeBytes(data, data.length - totalWritten, totalWritten);
+        if (written == -1) {
+          int errorCode = serialPort.getLastErrorCode();
+          throw new Exception(
+              "failed to write to port '%s', lastErrorCode=%d"
+                  .formatted(config.serialPort(), errorCode));
+        }
+        totalWritten += written;
+      }
+
+      return CompletableFuture.completedFuture(null);
+    } catch (Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  @Override
+  public void receive(Consumer<ModbusRtuFrame> frameReceiver) {
     this.frameReceiver.set(frameReceiver);
+  }
+
+  @Override
+  public void resetFrameParser() {
+    frameParser.reset();
   }
 
   private class ModbusRtuDataListener implements SerialPortDataListener {
@@ -131,61 +167,30 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
       }
     }
 
-    private void onFrameReceived(ModbusRtuFrame requestFrame) {
-      FrameReceiver<ModbusRtuRequestContext, ModbusRtuFrame> frameReceiver =
-          SerialPortServerTransport.this.frameReceiver.get();
-
+    private void onFrameReceived(ModbusRtuFrame frame) {
+      Consumer<ModbusRtuFrame> frameReceiver = SerialPortClientTransport.this.frameReceiver.get();
       if (frameReceiver != null) {
-        executionQueue.submit(() -> {
-          try {
-            ModbusRtuFrame responseFrame =
-                frameReceiver.receive(new ModbusRtuRequestContext() {}, requestFrame);
-
-            int unitId = responseFrame.unitId();
-            ByteBuffer pdu = responseFrame.pdu();
-            ByteBuffer crc = responseFrame.crc();
-
-            byte[] data = new byte[1 + pdu.remaining() + crc.remaining()];
-            data[0] = (byte) unitId;
-            pdu.get(data, 1, pdu.remaining());
-            crc.get(data, data.length - 2, crc.remaining());
-
-            int totalWritten = 0;
-            while (totalWritten < data.length) {
-              int written = serialPort.writeBytes(data, data.length - totalWritten, totalWritten);
-              if (written == -1) {
-                logger.error("Error writing frame to serial port");
-
-                return;
-              }
-              totalWritten += written;
-            }
-          } catch (UnknownUnitIdException e) {
-            logger.debug("Ignoring request for unknown unit id: {}", requestFrame.unitId());
-          } catch (Exception e) {
-            logger.error("Error handling frame: {}", e.getMessage(), e);
-          }
-        });
+        executionQueue.submit(() -> frameReceiver.accept(frame));
       }
     }
 
   }
 
   /**
-   * Create a new {@link SerialPortServerTransport} with a callback that allows customizing the
+   * Create a new {@link SerialPortClientTransport} with a callback that allows customizing the
    * configuration.
    *
    * @param configure a {@link Consumer} that accepts a
    *     {@link SerialPortTransportConfig.Builder} instance to configure.
-   * @return a new {@link SerialPortServerTransport}.
+   * @return a new {@link SerialPortClientTransport}.
    */
-  public static SerialPortServerTransport create(
-      Consumer<Builder> configure
+  public static SerialPortClientTransport create(
+      Consumer<SerialPortTransportConfig.Builder> configure
   ) {
 
     var builder = new SerialPortTransportConfig.Builder();
     configure.accept(builder);
-    return new SerialPortServerTransport(builder.build());
+    return new SerialPortClientTransport(builder.build());
   }
 
 }

--- a/modbus-tcp/pom.xml
+++ b/modbus-tcp/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>modbus-tcp</artifactId>
 
   <properties>
+    <javaModuleName>com.digitalpetri.modbus.tcp</javaModuleName>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/ModbusTcpCodec.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/ModbusTcpCodec.java
@@ -1,5 +1,7 @@
-package com.digitalpetri.modbus;
+package com.digitalpetri.modbus.tcp;
 
+import com.digitalpetri.modbus.MbapHeader;
+import com.digitalpetri.modbus.ModbusTcpFrame;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageCodec;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/Netty.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/Netty.java
@@ -1,4 +1,4 @@
-package com.digitalpetri.modbus;
+package com.digitalpetri.modbus.tcp;
 
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyClientTransportConfig.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyClientTransportConfig.java
@@ -1,7 +1,7 @@
-package com.digitalpetri.modbus.client;
+package com.digitalpetri.modbus.tcp.client;
 
 import com.digitalpetri.modbus.Modbus;
-import com.digitalpetri.modbus.Netty;
+import com.digitalpetri.modbus.tcp.Netty;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyRtuClientTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyRtuClientTransport.java
@@ -1,4 +1,4 @@
-package com.digitalpetri.modbus.client;
+package com.digitalpetri.modbus.tcp.client;
 
 import com.digitalpetri.fsm.FsmContext;
 import com.digitalpetri.modbus.ModbusRtuFrame;
@@ -6,6 +6,7 @@ import com.digitalpetri.modbus.ModbusRtuResponseFrameParser;
 import com.digitalpetri.modbus.ModbusRtuResponseFrameParser.Accumulated;
 import com.digitalpetri.modbus.ModbusRtuResponseFrameParser.ParseError;
 import com.digitalpetri.modbus.ModbusRtuResponseFrameParser.ParserState;
+import com.digitalpetri.modbus.client.ModbusRtuClientTransport;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;
 import com.digitalpetri.netty.fsm.ChannelActions;
 import com.digitalpetri.netty.fsm.ChannelFsm;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTcpClientTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTcpClientTransport.java
@@ -1,9 +1,10 @@
-package com.digitalpetri.modbus.client;
+package com.digitalpetri.modbus.tcp.client;
 
 import com.digitalpetri.fsm.FsmContext;
-import com.digitalpetri.modbus.ModbusTcpCodec;
 import com.digitalpetri.modbus.ModbusTcpFrame;
+import com.digitalpetri.modbus.client.ModbusTcpClientTransport;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;
+import com.digitalpetri.modbus.tcp.ModbusTcpCodec;
 import com.digitalpetri.netty.fsm.ChannelActions;
 import com.digitalpetri.netty.fsm.ChannelFsm;
 import com.digitalpetri.netty.fsm.ChannelFsmConfig;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTimeoutScheduler.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/client/NettyTimeoutScheduler.java
@@ -1,4 +1,4 @@
-package com.digitalpetri.modbus.client;
+package com.digitalpetri.modbus.tcp.client;
 
 import com.digitalpetri.modbus.TimeoutScheduler;
 import io.netty.util.HashedWheelTimer;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/server/NettyServerTransportConfig.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/server/NettyServerTransportConfig.java
@@ -1,7 +1,7 @@
-package com.digitalpetri.modbus.server;
+package com.digitalpetri.modbus.tcp.server;
 
 import com.digitalpetri.modbus.Modbus;
-import com.digitalpetri.modbus.Netty;
+import com.digitalpetri.modbus.tcp.Netty;
 import io.netty.channel.EventLoopGroup;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;

--- a/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/server/NettyTcpServerTransport.java
+++ b/modbus-tcp/src/main/java/com/digitalpetri/modbus/tcp/server/NettyTcpServerTransport.java
@@ -1,15 +1,11 @@
-package com.digitalpetri.modbus.server;
+package com.digitalpetri.modbus.tcp.server;
 
-import com.digitalpetri.modbus.ModbusRtuFrame;
-import com.digitalpetri.modbus.ModbusRtuRequestFrameParser;
-import com.digitalpetri.modbus.ModbusRtuRequestFrameParser.Accumulated;
-import com.digitalpetri.modbus.ModbusRtuRequestFrameParser.ParseError;
-import com.digitalpetri.modbus.ModbusRtuRequestFrameParser.ParserState;
+import com.digitalpetri.modbus.ModbusTcpFrame;
 import com.digitalpetri.modbus.exceptions.UnknownUnitIdException;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;
+import com.digitalpetri.modbus.server.ModbusTcpServerTransport;
+import com.digitalpetri.modbus.tcp.ModbusTcpCodec;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -21,40 +17,44 @@ import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import java.net.SocketAddress;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Modbus RTU/TCP server transport; a {@link ModbusRtuServerTransport} that sends and receives
- * {@link ModbusRtuFrame}s over TCP.
+ * Modbus/TCP transport; a {@link ModbusTcpServerTransport} that sends and receives
+ * {@link ModbusTcpFrame}s over TCP.
  */
-public class NettyRtuServerTransport implements ModbusRtuServerTransport {
+public class NettyTcpServerTransport implements ModbusTcpServerTransport {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
-  private final AtomicReference<FrameReceiver<ModbusRtuRequestContext, ModbusRtuFrame>>
+  private final AtomicReference<FrameReceiver<ModbusTcpRequestContext, ModbusTcpFrame>>
       frameReceiver = new AtomicReference<>();
-  private final ModbusRtuRequestFrameParser frameParser = new ModbusRtuRequestFrameParser();
 
   private final AtomicReference<ServerSocketChannel> serverChannel = new AtomicReference<>();
-
-  private final AtomicReference<Channel> clientChannel = new AtomicReference<>();
+  private final List<Channel> clientChannels = new CopyOnWriteArrayList<>();
 
   private final ExecutionQueue executionQueue;
   private final NettyServerTransportConfig config;
 
-  public NettyRtuServerTransport(NettyServerTransportConfig config) {
+  public NettyTcpServerTransport(NettyServerTransportConfig config) {
     this.config = config;
 
     executionQueue = new ExecutionQueue(config.executor(), 1);
   }
 
   @Override
-  public CompletionStage<Void> bind() {
+  public void receive(FrameReceiver<ModbusTcpRequestContext, ModbusTcpFrame> frameReceiver) {
+    this.frameReceiver.set(frameReceiver);
+  }
+
+  @Override
+  public CompletableFuture<Void> bind() {
     final var future = new CompletableFuture<Void>();
 
     var bootstrap = new ServerBootstrap();
@@ -63,18 +63,17 @@ public class NettyRtuServerTransport implements ModbusRtuServerTransport {
         .childHandler(new ChannelInitializer<SocketChannel>() {
           @Override
           protected void initChannel(SocketChannel ch) {
-            if (clientChannel.compareAndSet(null, ch)) {
-              ch.pipeline()
-                  .addLast(new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelInactive(ChannelHandlerContext ctx) {
-                      clientChannel.set(null);
-                    }
-                  })
-                  .addLast(new ModbusRtuServerFrameReceiver());
-            } else {
-              ch.close();
-            }
+            clientChannels.add(ch);
+
+            ch.pipeline()
+                .addLast(new ChannelInboundHandlerAdapter() {
+                  @Override
+                  public void channelInactive(ChannelHandlerContext ctx) {
+                    clientChannels.remove(ctx.channel());
+                  }
+                })
+                .addLast(new ModbusTcpCodec())
+                .addLast(new ModbusTcpFrameHandler());
           }
         });
 
@@ -97,16 +96,14 @@ public class NettyRtuServerTransport implements ModbusRtuServerTransport {
   }
 
   @Override
-  public CompletionStage<Void> unbind() {
+  public CompletableFuture<Void> unbind() {
     ServerSocketChannel channel = serverChannel.getAndSet(null);
 
     if (channel != null) {
       var future = new CompletableFuture<Void>();
       channel.close().addListener((ChannelFutureListener) cf -> {
-        Channel ch = clientChannel.getAndSet(null);
-        if (ch != null) {
-          ch.close();
-        }
+        clientChannels.forEach(Channel::close);
+        clientChannels.clear();
 
         if (cf.isSuccess()) {
           future.complete(null);
@@ -120,52 +117,23 @@ public class NettyRtuServerTransport implements ModbusRtuServerTransport {
     }
   }
 
-  @Override
-  public void receive(FrameReceiver<ModbusRtuRequestContext, ModbusRtuFrame> frameReceiver) {
-    this.frameReceiver.set(frameReceiver);
-  }
-
-  private class ModbusRtuServerFrameReceiver extends SimpleChannelInboundHandler<ByteBuf> {
+  private class ModbusTcpFrameHandler extends SimpleChannelInboundHandler<ModbusTcpFrame> {
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, ByteBuf buffer) {
-      byte[] data = new byte[buffer.readableBytes()];
-      buffer.readBytes(data);
-
-      ParserState state = frameParser.parse(data);
-
-      if (state instanceof Accumulated a) {
-        try {
-          onFrameReceived(ctx, a.frame());
-        } finally {
-          frameParser.reset();
-        }
-      } else if (state instanceof ParseError e) {
-        logger.error("Error parsing frame: {}", e.message());
-
-        frameParser.reset();
-        ctx.close();
-      }
-    }
-
-    private void onFrameReceived(ChannelHandlerContext ctx, ModbusRtuFrame requestFrame) {
-      FrameReceiver<ModbusRtuRequestContext, ModbusRtuFrame> frameReceiver =
-          NettyRtuServerTransport.this.frameReceiver.get();
+    protected void channelRead0(ChannelHandlerContext ctx, ModbusTcpFrame requestFrame) {
+      FrameReceiver<ModbusTcpRequestContext, ModbusTcpFrame> frameReceiver =
+          NettyTcpServerTransport.this.frameReceiver.get();
 
       if (frameReceiver != null) {
         executionQueue.submit(() -> {
           try {
-            ModbusRtuFrame responseFrame =
+            ModbusTcpFrame responseFrame =
                 frameReceiver.receive(requestContext(ctx), requestFrame);
 
-            ByteBuf buffer = Unpooled.buffer();
-            buffer.writeByte(responseFrame.unitId());
-            buffer.writeBytes(responseFrame.pdu());
-            buffer.writeBytes(responseFrame.crc());
-
-            ctx.channel().writeAndFlush(buffer);
+            ctx.channel().writeAndFlush(responseFrame);
           } catch (UnknownUnitIdException e) {
-            logger.debug("Ignoring request for unknown unit id: {}", requestFrame.unitId());
+            logger.debug(
+                "Ignoring request for unknown unit id: {}", requestFrame.header().unitId());
           } catch (Exception e) {
             logger.error("Error handling frame: {}", e.getMessage(), e);
 
@@ -173,11 +141,10 @@ public class NettyRtuServerTransport implements ModbusRtuServerTransport {
           }
         });
       }
-
     }
 
-    private static ModbusRtuTcpRequestContext requestContext(ChannelHandlerContext ctx) {
-      return new ModbusRtuTcpRequestContext() {
+    private static ModbusTcpRequestContext requestContext(ChannelHandlerContext ctx) {
+      return new ModbusTcpRequestContext() {
         @Override
         public SocketAddress localAddress() {
           return ctx.channel().localAddress();
@@ -193,20 +160,20 @@ public class NettyRtuServerTransport implements ModbusRtuServerTransport {
   }
 
   /**
-   * Create a new {@link NettyRtuServerTransport} with a callback that allows customizing the
+   * Create a new {@link NettyTcpServerTransport} with a callback that allows customizing the
    * configuration.
    *
    * @param configure a {@link Consumer} that accepts a
    *     {@link NettyServerTransportConfig.Builder} instance to configure.
-   * @return a new {@link NettyRtuServerTransport}.
+   * @return a new {@link NettyTcpServerTransport}.
    */
-  public static NettyRtuServerTransport create(
+  public static NettyTcpServerTransport create(
       Consumer<NettyServerTransportConfig.Builder> configure
   ) {
 
     var builder = new NettyServerTransportConfig.Builder();
     configure.accept(builder);
-    return new NettyRtuServerTransport(builder.build());
+    return new NettyTcpServerTransport(builder.build());
   }
 
 }

--- a/modbus-tcp/src/test/java/com/digitalpetri/modbus/tcp/ModbusTcpCodecTest.java
+++ b/modbus-tcp/src/test/java/com/digitalpetri/modbus/tcp/ModbusTcpCodecTest.java
@@ -1,7 +1,9 @@
-package com.digitalpetri.modbus;
+package com.digitalpetri.modbus.tcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.digitalpetri.modbus.MbapHeader;
+import com.digitalpetri.modbus.ModbusTcpFrame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.embedded.EmbeddedChannel;

--- a/modbus-tests/pom.xml
+++ b/modbus-tests/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>modbus-tests</artifactId>
 
   <properties>
+    <javaModuleName>com.digitalpetri.modbus.test</javaModuleName>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ClientServerIT.java
+++ b/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ClientServerIT.java
@@ -1,4 +1,4 @@
-package modbus;
+package com.digitalpetri.modbus.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusRtuClientServerIT.java
+++ b/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusRtuClientServerIT.java
@@ -1,13 +1,13 @@
-package modbus;
+package com.digitalpetri.modbus.test;
 
 import com.digitalpetri.modbus.client.ModbusClient;
 import com.digitalpetri.modbus.client.ModbusRtuClient;
-import com.digitalpetri.modbus.client.SerialPortClientTransport;
+import com.digitalpetri.modbus.serial.client.SerialPortClientTransport;
+import com.digitalpetri.modbus.serial.server.SerialPortServerTransport;
 import com.digitalpetri.modbus.server.ModbusRtuServer;
 import com.digitalpetri.modbus.server.ModbusServer;
 import com.digitalpetri.modbus.server.ProcessImage;
 import com.digitalpetri.modbus.server.ReadWriteModbusServices;
-import com.digitalpetri.modbus.server.SerialPortServerTransport;
 import com.fazecast.jSerialComm.SerialPort;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;

--- a/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusRtuTcpClientServerIT.java
+++ b/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusRtuTcpClientServerIT.java
@@ -1,13 +1,13 @@
-package modbus;
+package com.digitalpetri.modbus.test;
 
 import com.digitalpetri.modbus.client.ModbusClient;
 import com.digitalpetri.modbus.client.ModbusRtuClient;
-import com.digitalpetri.modbus.client.NettyRtuClientTransport;
 import com.digitalpetri.modbus.server.ModbusRtuServer;
 import com.digitalpetri.modbus.server.ModbusServer;
-import com.digitalpetri.modbus.server.NettyRtuServerTransport;
 import com.digitalpetri.modbus.server.ProcessImage;
 import com.digitalpetri.modbus.server.ReadWriteModbusServices;
+import com.digitalpetri.modbus.tcp.client.NettyRtuClientTransport;
+import com.digitalpetri.modbus.tcp.server.NettyRtuServerTransport;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusTcpClientServerIT.java
+++ b/modbus-tests/src/test/java/com/digitalpetri/modbus/test/ModbusTcpClientServerIT.java
@@ -1,18 +1,18 @@
-package modbus;
+package com.digitalpetri.modbus.test;
 
 import com.digitalpetri.modbus.ModbusPduSerializer.DefaultRequestSerializer;
-import com.digitalpetri.modbus.Netty;
 import com.digitalpetri.modbus.client.ModbusClient;
 import com.digitalpetri.modbus.client.ModbusTcpClient;
-import com.digitalpetri.modbus.client.NettyTcpClientTransport;
-import com.digitalpetri.modbus.client.NettyTimeoutScheduler;
 import com.digitalpetri.modbus.internal.util.Hex;
 import com.digitalpetri.modbus.pdu.ReadHoldingRegistersRequest;
 import com.digitalpetri.modbus.server.ModbusServer;
 import com.digitalpetri.modbus.server.ModbusTcpServer;
-import com.digitalpetri.modbus.server.NettyTcpServerTransport;
 import com.digitalpetri.modbus.server.ProcessImage;
 import com.digitalpetri.modbus.server.ReadWriteModbusServices;
+import com.digitalpetri.modbus.tcp.Netty;
+import com.digitalpetri.modbus.tcp.client.NettyTcpClientTransport;
+import com.digitalpetri.modbus.tcp.client.NettyTimeoutScheduler;
+import com.digitalpetri.modbus.tcp.server.NettyTcpServerTransport;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;

--- a/modbus/pom.xml
+++ b/modbus/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>modbus</artifactId>
 
   <properties>
+    <javaModuleName>com.digitalpetri.modbus</javaModuleName>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,22 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.2.0</version>
+            <configuration>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                </manifest>
+                <manifestEntries>
+                  <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                </manifestEntries>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.8.0</version>
             <executions>


### PR DESCRIPTION
- Move `modbus-tcp` classes to `com.digitalpetri.modbus.tcp`
- Move `modbus-serial` classes to `com.digitalpetri.modbus.serial`
- Move `modbus-test` classes to `com.digitalpetri.modbus.test`
- Explicitly assign Java module names rather than relying on automatic module names

fixes #82