### PR TITLE
Encode WriteMultipleRegistersRequest using `values` length

### DIFF
--- a/modbus/src/main/java/com/digitalpetri/modbus/pdu/WriteMultipleRegistersRequest.java
+++ b/modbus/src/main/java/com/digitalpetri/modbus/pdu/WriteMultipleRegistersRequest.java
@@ -69,8 +69,7 @@ public record WriteMultipleRegistersRequest(int address, int quantity, byte[] va
       buffer.putShort((short) request.address);
       buffer.putShort((short) request.quantity);
 
-      int byteCount = request.quantity * 2;
-      buffer.put((byte) byteCount);
+      buffer.put((byte) request.values.length);
       buffer.put(request.values);
     }
 


### PR DESCRIPTION
Encode the "Byte Count" field of a WriteMultipleRegistersRequest using the length of the `values` bytes rather than multiplying `quantity` by 2.

This allows the request to be used with non-standard Modbus implementations e.g. those that use 32-bit registers instead of the standard 16-bit registers.