### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,17 +48,17 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Dependencies -->
-    <jserialcomm.version>2.11.0</jserialcomm.version>
-    <netty.version>4.1.119.Final</netty.version>
-    <netty-channel-fsm.version>1.0.0</netty-channel-fsm.version>
+    <jserialcomm.version>2.11.2</jserialcomm.version>
+    <netty.version>4.1.122.Final</netty.version>
+    <netty-channel-fsm.version>1.0.1</netty-channel-fsm.version>
     <slf4j.version>2.0.17</slf4j.version>
 
     <!-- Test Dependencies -->
     <bouncycastle.version>1.80</bouncycastle.version>
-    <junit.version>5.12.1</junit.version>
+    <junit.version>5.13.3</junit.version>
 
     <!-- Plugin Dependencies -->
-    <checkstyle.version>10.21.4</checkstyle.version>
+    <checkstyle.version>10.26.1</checkstyle.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>


### PR DESCRIPTION
- jSerialComm to version 2.11.2
- Netty to version 4.1.122.Final
- netty-channel-fsm to version 1.0.1
- JUnit to version 5.13.3
- Checkstyle to version 10.26.1