### PR TITLE
Handle empty response PDU in `ModbusTcpClient`

### DIFF
--- a/modbus-tcp/src/test/java/com/digitalpetri/modbus/tcp/ModbusTcpCodecTest.java
+++ b/modbus-tcp/src/test/java/com/digitalpetri/modbus/tcp/ModbusTcpCodecTest.java
@@ -6,6 +6,7 @@ import com.digitalpetri.modbus.MbapHeader;
 import com.digitalpetri.modbus.ModbusTcpFrame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
@@ -33,5 +34,17 @@ class ModbusTcpCodecTest {
     System.out.println(decoded);
 
     assertEquals(frame, decoded);
+  }
+
+  @Test
+  void emptyPdu() {
+    var rx = Unpooled.copiedBuffer(ByteBufUtil.decodeHexDump("5FFD0000000101"));
+    var channel = new EmbeddedChannel(new ModbusTcpCodec());
+
+    channel.writeInbound(rx);
+    ModbusTcpFrame frame = channel.readInbound();
+
+    System.out.println(frame);
+    assertEquals(0, frame.pdu().remaining());
   }
 }

--- a/modbus/src/main/java/com/digitalpetri/modbus/client/ModbusTcpClient.java
+++ b/modbus/src/main/java/com/digitalpetri/modbus/client/ModbusTcpClient.java
@@ -172,6 +172,12 @@ public class ModbusTcpClient extends ModbusClient {
       promise.timeout.cancel();
 
       ByteBuffer buffer = frame.pdu();
+
+      if (buffer.remaining() == 0) {
+        promise.future.completeExceptionally(new ModbusException("empty response PDU"));
+        return;
+      }
+
       int functionCode = buffer.get(buffer.position()) & 0xFF;
 
       if (functionCode == promise.functionCode) {

--- a/modbus/src/test/java/com/digitalpetri/modbus/client/ModbusTcpClientTest.java
+++ b/modbus/src/test/java/com/digitalpetri/modbus/client/ModbusTcpClientTest.java
@@ -1,0 +1,75 @@
+package com.digitalpetri.modbus.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.digitalpetri.modbus.MbapHeader;
+import com.digitalpetri.modbus.ModbusTcpFrame;
+import com.digitalpetri.modbus.exceptions.ModbusException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+public class ModbusTcpClientTest {
+
+  /**
+   * Tests handling of an erroneous empty response PDU.
+   *
+   * @see <a
+   *     href="https://github.com/digitalpetri/modbus/issues/121">https://github.com/digitalpetri/modbus/issues/121</a>
+   */
+  @Test
+  void emptyResponsePdu() {
+    var transport = new TestTransport();
+    var client = ModbusTcpClient.create(transport);
+
+    CompletionStage<byte[]> cs = client.sendRawAsync(1, new byte[] {0x04, 0x03, 0x00, 0x00, 0x01});
+
+    transport.frameReceiver.accept(
+        new ModbusTcpFrame(new MbapHeader(0, 1, 1, 1), ByteBuffer.allocate(0)));
+
+    ExecutionException ex =
+        assertThrows(ExecutionException.class, () -> cs.toCompletableFuture().get());
+
+    ModbusException cause = (ModbusException) ex.getCause();
+    assertEquals("empty response PDU", cause.getMessage());
+  }
+
+  private static class TestTransport implements ModbusTcpClientTransport {
+
+    boolean connected = false;
+    ModbusTcpFrame lastFrameSent;
+    Consumer<ModbusTcpFrame> frameReceiver;
+
+    @Override
+    public CompletionStage<Void> connect() {
+      connected = true;
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> disconnect() {
+      connected = false;
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public boolean isConnected() {
+      return connected;
+    }
+
+    @Override
+    public CompletionStage<Void> send(ModbusTcpFrame frame) {
+      lastFrameSent = frame;
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void receive(Consumer<ModbusTcpFrame> frameReceiver) {
+      this.frameReceiver = frameReceiver;
+    }
+  }
+}


### PR DESCRIPTION
fixes #121