### PR TITLE
Add Spotless plugin to enforce code formatting

### DIFF
--- a/modbus/src/test/java/com/digitalpetri/modbus/client/ModbusTcpClientTest.java
+++ b/modbus/src/test/java/com/digitalpetri/modbus/client/ModbusTcpClientTest.java
@@ -52,8 +52,7 @@ public class ModbusTcpClientTest {
 
     // Receive a malformed exception response: only 1 byte (0x84), no exception code
     transport.frameReceiver.accept(
-        new ModbusTcpFrame(
-            new MbapHeader(0, 1, 1, 1), ByteBuffer.wrap(new byte[] {(byte) 0x84})));
+        new ModbusTcpFrame(new MbapHeader(0, 1, 1, 1), ByteBuffer.wrap(new byte[] {(byte) 0x84})));
 
     ExecutionException ex =
         assertThrows(ExecutionException.class, () -> cs.toCompletableFuture().get());

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+    <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.19.1</versions-maven-plugin.version>
   </properties>
 
@@ -423,6 +424,23 @@
             </rules>
           </ruleSet>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless-maven-plugin.version}</version>
+        <configuration>
+          <java>
+            <googleJavaFormat/>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Defined `spotless-maven-plugin` version in properties.
- Configured Spotless Maven plugin with Google Java Format.
- Added execution to check code formatting during the build process.