### PR TITLE
Update dependency and plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,31 +49,31 @@
 
     <!-- Dependencies -->
     <jserialcomm.version>2.11.4</jserialcomm.version>
-    <netty.version>4.1.128.Final</netty.version>
+    <netty.version>4.1.131.Final</netty.version>
     <netty-channel-fsm.version>1.0.2</netty-channel-fsm.version>
     <slf4j.version>2.0.17</slf4j.version>
 
     <!-- Test Dependencies -->
-    <bouncycastle.version>1.82</bouncycastle.version>
-    <junit.version>5.14.1</junit.version>
+    <bouncycastle.version>1.83</bouncycastle.version>
+    <junit.version>5.14.3</junit.version>
 
     <!-- Plugin Dependencies -->
-    <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
     <checkstyle.version>11.1.0</checkstyle.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-    <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
-    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
-    <versions-maven-plugin.version>2.19.1</versions-maven-plugin.version>
+    <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+    <maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
+    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+    <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
+    <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -138,7 +138,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.4.2</version>
+            <version>${maven-jar-plugin.version}</version>
             <configuration>
               <archive>
                 <manifest>
@@ -247,7 +247,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.4.2</version>
+            <version>${maven-jar-plugin.version}</version>
             <configuration>
               <archive>
                 <manifest>


### PR DESCRIPTION
Dependencies:
- Netty 4.1.128.Final -> 4.1.131.Final
- JUnit 5.14.1 -> 5.14.3
- BouncyCastle 1.82 -> 1.83

Plugins:
- spotless-maven-plugin 3.0.0 -> 3.2.1
- maven-compiler-plugin 3.14.1 -> 3.15.0
- maven-dependency-plugin 3.9.0 -> 3.10.0
- maven-jar-plugin 3.4.2 -> 3.5.0
- maven-release-plugin 3.1.1 -> 3.3.1
- maven-resources-plugin 3.3.1 -> 3.4.0
- maven-source-plugin 3.3.1 -> 3.4.0
- versions-maven-plugin 2.19.1 -> 2.21.0
- central-publishing-maven-plugin 0.9.0 -> 0.10.0