### PR TITLE
Lazy-initialize SerialPort in transport classes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
@@ -79,7 +79,7 @@ public class SerialPortClientTransport implements ModbusRtuClientTransport {
       sp = getSerialPort();
     } catch (ModbusException e) {
       return CompletableFuture.failedFuture(
-          new ModbusConnectException(e.getMessage(), e.getCause()));
+          new ModbusConnectException(e.getMessage(), e));
     }
 
     if (sp.isOpen()) {

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
@@ -141,7 +141,7 @@ public class SerialPortClientTransport implements ModbusRtuClientTransport {
   @Override
   public CompletionStage<Void> send(ModbusRtuFrame frame) {
     SerialPort sp = this.serialPort;
-    if (sp == null) {
+    if (sp == null || !sp.isOpen()) {
       return CompletableFuture.failedFuture(new ModbusException("not connected"));
     }
 

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
@@ -5,6 +5,8 @@ import com.digitalpetri.modbus.ModbusRtuResponseFrameParser;
 import com.digitalpetri.modbus.ModbusRtuResponseFrameParser.Accumulated;
 import com.digitalpetri.modbus.ModbusRtuResponseFrameParser.ParserState;
 import com.digitalpetri.modbus.client.ModbusRtuClientTransport;
+import com.digitalpetri.modbus.exceptions.ModbusConnectException;
+import com.digitalpetri.modbus.exceptions.ModbusException;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;
 import com.digitalpetri.modbus.serial.SerialPortTransportConfig;
 import com.fazecast.jSerialComm.SerialPort;
@@ -27,21 +29,12 @@ public class SerialPortClientTransport implements ModbusRtuClientTransport {
 
   private final ExecutionQueue executionQueue;
 
-  private final SerialPort serialPort;
+  private volatile SerialPort serialPort;
 
   private final SerialPortTransportConfig config;
 
   public SerialPortClientTransport(SerialPortTransportConfig config) {
     this.config = config;
-
-    serialPort = SerialPort.getCommPort(config.serialPort());
-
-    serialPort.setComPortParameters(
-        config.baudRate(),
-        config.dataBits(),
-        config.stopBits(),
-        config.parity(),
-        config.rs485Mode());
 
     executionQueue = new ExecutionQueue(config.executor());
   }
@@ -49,45 +42,84 @@ public class SerialPortClientTransport implements ModbusRtuClientTransport {
   /**
    * Return the underlying {@link SerialPort} used by this transport.
    *
+   * <p>The serial port is lazily instantiated on first access.
+   *
    * @return the configured {@link SerialPort} instance.
+   * @throws ModbusException if the serial port could not be created.
    */
-  public SerialPort getSerialPort() {
-    return serialPort;
+  public SerialPort getSerialPort() throws ModbusException {
+    SerialPort sp = this.serialPort;
+    if (sp == null) {
+      synchronized (this) {
+        sp = this.serialPort;
+        if (sp == null) {
+          try {
+            sp = SerialPort.getCommPort(config.serialPort());
+            sp.setComPortParameters(
+                config.baudRate(),
+                config.dataBits(),
+                config.stopBits(),
+                config.parity(),
+                config.rs485Mode());
+            this.serialPort = sp;
+          } catch (Exception e) {
+            throw new ModbusException(
+                "failed to get comm port '%s'".formatted(config.serialPort()), e);
+          }
+        }
+      }
+    }
+    return sp;
   }
 
   @Override
   public synchronized CompletableFuture<Void> connect() {
-    if (serialPort.isOpen()) {
+    SerialPort sp;
+    try {
+      sp = getSerialPort();
+    } catch (ModbusException e) {
+      return CompletableFuture.failedFuture(
+          new ModbusConnectException(e.getMessage(), e.getCause()));
+    }
+
+    if (sp.isOpen()) {
       return CompletableFuture.completedFuture(null);
     } else {
-      if (serialPort.openPort()) {
+      if (sp.openPort()) {
         frameParser.reset();
 
         // note: no-op if already added from previous connect()
-        serialPort.addDataListener(new ModbusRtuDataListener());
+        sp.addDataListener(new ModbusRtuDataListener());
 
         return CompletableFuture.completedFuture(null);
       } else {
         return CompletableFuture.failedFuture(
-            new Exception(
+            new ModbusConnectException(
                 "failed to open port '%s', lastErrorCode=%d"
-                    .formatted(config.serialPort(), serialPort.getLastErrorCode())));
+                    .formatted(config.serialPort(), sp.getLastErrorCode())));
       }
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned {@link CompletionStage} may complete exceptionally with a {@link
+   * ModbusException} if the serial port could not be closed.
+   */
   @Override
   public synchronized CompletableFuture<Void> disconnect() {
-    if (serialPort.isOpen()) {
-      if (serialPort.closePort()) {
+    SerialPort sp = this.serialPort;
+    if (sp != null && sp.isOpen()) {
+      if (sp.closePort()) {
         frameParser.reset();
 
         return CompletableFuture.completedFuture(null);
       } else {
         return CompletableFuture.failedFuture(
-            new Exception(
+            new ModbusException(
                 "failed to close port '%s', lastErrorCode=%d"
-                    .formatted(config.serialPort(), serialPort.getLastErrorCode())));
+                    .formatted(config.serialPort(), sp.getLastErrorCode())));
       }
     } else {
       return CompletableFuture.completedFuture(null);
@@ -96,11 +128,23 @@ public class SerialPortClientTransport implements ModbusRtuClientTransport {
 
   @Override
   public boolean isConnected() {
-    return serialPort.isOpen();
+    SerialPort sp = this.serialPort;
+    return sp != null && sp.isOpen();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned {@link CompletionStage} may complete exceptionally with a {@link
+   * ModbusException} if the transport is not connected or if writing to the serial port fails.
+   */
   @Override
   public CompletionStage<Void> send(ModbusRtuFrame frame) {
+    SerialPort sp = this.serialPort;
+    if (sp == null) {
+      return CompletableFuture.failedFuture(new ModbusException("not connected"));
+    }
+
     ByteBuffer buffer = ByteBuffer.allocate(256);
 
     try {
@@ -114,10 +158,10 @@ public class SerialPortClientTransport implements ModbusRtuClientTransport {
 
       int totalWritten = 0;
       while (totalWritten < data.length) {
-        int written = serialPort.writeBytes(data, data.length - totalWritten, totalWritten);
+        int written = sp.writeBytes(data, data.length - totalWritten, totalWritten);
         if (written == -1) {
-          int errorCode = serialPort.getLastErrorCode();
-          throw new Exception(
+          int errorCode = sp.getLastErrorCode();
+          throw new ModbusException(
               "failed to write to port '%s', lastErrorCode=%d"
                   .formatted(config.serialPort(), errorCode));
         }

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/server/SerialPortServerTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/server/SerialPortServerTransport.java
@@ -86,8 +86,7 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
     try {
       sp = getSerialPort();
     } catch (ModbusException e) {
-      return CompletableFuture.failedFuture(
-          new ModbusConnectException(e.getMessage(), e.getCause()));
+      return CompletableFuture.failedFuture(new ModbusConnectException(e));
     }
 
     if (sp.isOpen()) {

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/server/SerialPortServerTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/server/SerialPortServerTransport.java
@@ -4,6 +4,8 @@ import com.digitalpetri.modbus.ModbusRtuFrame;
 import com.digitalpetri.modbus.ModbusRtuRequestFrameParser;
 import com.digitalpetri.modbus.ModbusRtuRequestFrameParser.Accumulated;
 import com.digitalpetri.modbus.ModbusRtuRequestFrameParser.ParserState;
+import com.digitalpetri.modbus.exceptions.ModbusConnectException;
+import com.digitalpetri.modbus.exceptions.ModbusException;
 import com.digitalpetri.modbus.exceptions.UnknownUnitIdException;
 import com.digitalpetri.modbus.internal.util.ExecutionQueue;
 import com.digitalpetri.modbus.serial.SerialPortTransportConfig;
@@ -35,21 +37,12 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
 
   private final ExecutionQueue executionQueue;
 
-  private final SerialPort serialPort;
+  private volatile SerialPort serialPort;
 
   private final SerialPortTransportConfig config;
 
   public SerialPortServerTransport(SerialPortTransportConfig config) {
     this.config = config;
-
-    serialPort = SerialPort.getCommPort(config.serialPort());
-
-    serialPort.setComPortParameters(
-        config.baudRate(),
-        config.dataBits(),
-        config.stopBits(),
-        config.parity(),
-        config.rs485Mode());
 
     executionQueue = new ExecutionQueue(config.executor());
   }
@@ -57,44 +50,83 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
   /**
    * Return the underlying {@link SerialPort} used by this transport.
    *
+   * <p>The serial port is lazily instantiated on first access.
+   *
    * @return the configured {@link SerialPort} instance.
+   * @throws ModbusException if the serial port could not be created.
    */
-  public SerialPort getSerialPort() {
-    return serialPort;
+  public SerialPort getSerialPort() throws ModbusException {
+    SerialPort sp = this.serialPort;
+    if (sp == null) {
+      synchronized (this) {
+        sp = this.serialPort;
+        if (sp == null) {
+          try {
+            sp = SerialPort.getCommPort(config.serialPort());
+            sp.setComPortParameters(
+                config.baudRate(),
+                config.dataBits(),
+                config.stopBits(),
+                config.parity(),
+                config.rs485Mode());
+            this.serialPort = sp;
+          } catch (Exception e) {
+            throw new ModbusException(
+                "failed to get comm port '%s'".formatted(config.serialPort()), e);
+          }
+        }
+      }
+    }
+    return sp;
   }
 
   @Override
   public CompletionStage<Void> bind() {
-    if (serialPort.isOpen()) {
+    SerialPort sp;
+    try {
+      sp = getSerialPort();
+    } catch (ModbusException e) {
+      return CompletableFuture.failedFuture(
+          new ModbusConnectException(e.getMessage(), e.getCause()));
+    }
+
+    if (sp.isOpen()) {
       return CompletableFuture.completedFuture(null);
     } else {
-      if (serialPort.openPort()) {
+      if (sp.openPort()) {
         frameParser.reset();
 
-        serialPort.addDataListener(new ModbusRtuDataListener());
+        sp.addDataListener(new ModbusRtuDataListener());
 
         return CompletableFuture.completedFuture(null);
       } else {
         return CompletableFuture.failedFuture(
-            new Exception(
+            new ModbusConnectException(
                 "failed to open port '%s', lastErrorCode=%d"
-                    .formatted(config.serialPort(), serialPort.getLastErrorCode())));
+                    .formatted(config.serialPort(), sp.getLastErrorCode())));
       }
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned {@link CompletionStage} may complete exceptionally with a {@link
+   * ModbusException} if the serial port could not be closed.
+   */
   @Override
   public CompletionStage<Void> unbind() {
-    if (serialPort.isOpen()) {
-      if (serialPort.closePort()) {
+    SerialPort sp = this.serialPort;
+    if (sp != null && sp.isOpen()) {
+      if (sp.closePort()) {
         frameParser.reset();
 
         return CompletableFuture.completedFuture(null);
       } else {
         return CompletableFuture.failedFuture(
-            new Exception(
+            new ModbusException(
                 "failed to close port '%s', lastErrorCode=%d"
-                    .formatted(config.serialPort(), serialPort.getLastErrorCode())));
+                    .formatted(config.serialPort(), sp.getLastErrorCode())));
       }
     } else {
       return CompletableFuture.completedFuture(null);
@@ -157,10 +189,10 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
                 pdu.get(data, 1, pdu.remaining());
                 crc.get(data, data.length - 2, crc.remaining());
 
+                SerialPort sp = SerialPortServerTransport.this.serialPort;
                 int totalWritten = 0;
                 while (totalWritten < data.length) {
-                  int written =
-                      serialPort.writeBytes(data, data.length - totalWritten, totalWritten);
+                  int written = sp.writeBytes(data, data.length - totalWritten, totalWritten);
                   if (written == -1) {
                     logger.error("Error writing frame to serial port");
 

--- a/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/SerialPortGetCommPortBehaviorTest.java
+++ b/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/SerialPortGetCommPortBehaviorTest.java
@@ -1,7 +1,9 @@
 package com.digitalpetri.modbus.serial;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,14 +29,16 @@ import org.junit.jupiter.api.condition.OS;
  *   <li><b>Linux/macOS:</b> validates that the port descriptor exists on the filesystem (checking
  *       the path as-is, then with a {@code /dev/} prefix). Throws {@code
  *       SerialPortInvalidPortException} immediately if the file does not exist.
- *   <li><b>Windows:</b> does <em>not</em> check file existence — rewrites the descriptor to {@code
- *       \\.\COMx} format and defers validation to the native {@code retrievePortDetails()} call,
- *       which throws {@code SerialPortInvalidPortException} for invalid COM ports.
+ *   <li><b>Windows:</b> does <em>not</em> validate port existence — rewrites the descriptor to
+ *       {@code \\.\COMx} format and creates the {@link SerialPort} object successfully. The failure
+ *       is deferred to {@code openPort()}, which returns {@code false}.
  * </ul>
  *
- * <p>In both cases the result is the same: {@code getCommPort} throws for non-existent ports. The
- * transport classes defer this call to connect/bind time so the exception can be caught and wrapped
- * as a {@link ModbusConnectException}.
+ * <p>This behavioral difference is why the transport classes defer the {@code getCommPort} call to
+ * connect/bind time rather than calling it in the constructor. On Linux/macOS the deferred call
+ * allows the exception to be caught and wrapped as a {@link ModbusConnectException}. On Windows the
+ * constructor would have succeeded either way, but the deferred approach keeps the behavior
+ * consistent across platforms.
  */
 class SerialPortGetCommPortBehaviorTest {
 
@@ -51,6 +55,13 @@ class SerialPortGetCommPortBehaviorTest {
       // A path that doesn't exist on the filesystem causes an immediate exception.
       assertThrows(RuntimeException.class, () -> SerialPort.getCommPort(BOGUS_UNIX_PORT));
     }
+
+    @Test
+    void getCommPortThrowsForWindowsStyleDescriptor() {
+      // A Windows-style descriptor like "COM999" also fails on Linux/Mac because
+      // it doesn't exist on the filesystem (not under /dev/ either).
+      assertThrows(RuntimeException.class, () -> SerialPort.getCommPort(BOGUS_WINDOWS_PORT));
+    }
   }
 
   @Nested
@@ -58,11 +69,32 @@ class SerialPortGetCommPortBehaviorTest {
   class GetCommPortOnWindows {
 
     @Test
-    void getCommPortThrowsForInvalidComPort() {
+    void getCommPortDoesNotThrowForNonExistentComPort() {
       // On Windows, getCommPort rewrites the descriptor to \\.\COMx format
-      // without checking file existence. The native retrievePortDetails() call
-      // throws for COM ports that don't exist.
-      assertThrows(RuntimeException.class, () -> SerialPort.getCommPort(BOGUS_WINDOWS_PORT));
+      // and does not validate that the port exists. The SerialPort object is
+      // created successfully; failure is deferred to openPort().
+      SerialPort sp = assertDoesNotThrow(() -> SerialPort.getCommPort(BOGUS_WINDOWS_PORT));
+      assertNotNull(sp);
+    }
+
+    @Test
+    void getCommPortWithNonExistentComPortFailsToOpen() {
+      SerialPort sp = SerialPort.getCommPort(BOGUS_WINDOWS_PORT);
+      assertFalse(sp.openPort(), "opening a non-existent COM port should fail");
+    }
+
+    @Test
+    void getCommPortDoesNotThrowForUnixStyleDescriptor() {
+      // On Windows, getCommPort rewrites any descriptor to \\.\<name> format
+      // without filesystem validation, so even a Unix-style path succeeds.
+      SerialPort sp = assertDoesNotThrow(() -> SerialPort.getCommPort(BOGUS_UNIX_PORT));
+      assertNotNull(sp);
+    }
+
+    @Test
+    void getCommPortWithUnixStyleDescriptorFailsToOpen() {
+      SerialPort sp = SerialPort.getCommPort(BOGUS_UNIX_PORT);
+      assertFalse(sp.openPort(), "opening a Unix-style port on Windows should fail");
     }
   }
 
@@ -78,17 +110,33 @@ class SerialPortGetCommPortBehaviorTest {
     }
 
     @Test
-    void getSerialPortWrapsExceptionAsModbusException() {
-      String port = isWindows() ? BOGUS_WINDOWS_PORT : BOGUS_UNIX_PORT;
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    void getSerialPortThrowsOnLinuxMac() {
       SerialPortClientTransport transport =
-          SerialPortClientTransport.create(cfg -> cfg.setSerialPort(port));
+          SerialPortClientTransport.create(cfg -> cfg.setSerialPort(BOGUS_UNIX_PORT));
 
+      // On Linux/Mac, getCommPort throws for non-existent ports,
+      // which getSerialPort wraps as ModbusException.
       ModbusException ex = assertThrows(ModbusException.class, transport::getSerialPort);
-      assertTrue(ex.getMessage().contains(port));
+      assertTrue(ex.getMessage().contains(BOGUS_UNIX_PORT));
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void getSerialPortSucceedsOnWindows() throws ModbusException {
+      SerialPortClientTransport transport =
+          SerialPortClientTransport.create(cfg -> cfg.setSerialPort(BOGUS_WINDOWS_PORT));
+
+      // On Windows, getCommPort succeeds for non-existent COM ports,
+      // so getSerialPort also succeeds. Failure is deferred to connect/openPort.
+      assertDoesNotThrow(transport::getSerialPort);
     }
 
     @Test
     void connectFailsWithModbusConnectException() {
+      // On all platforms, connect with a bogus port results in ModbusConnectException.
+      // On Linux/Mac: getSerialPort() throws, caught and wrapped.
+      // On Windows: getSerialPort() succeeds, but openPort() returns false.
       String port = isWindows() ? BOGUS_WINDOWS_PORT : BOGUS_UNIX_PORT;
       SerialPortClientTransport transport =
           SerialPortClientTransport.create(cfg -> cfg.setSerialPort(port));
@@ -109,13 +157,22 @@ class SerialPortGetCommPortBehaviorTest {
     }
 
     @Test
-    void getSerialPortWrapsExceptionAsModbusException() {
-      String port = isWindows() ? BOGUS_WINDOWS_PORT : BOGUS_UNIX_PORT;
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    void getSerialPortThrowsOnLinuxMac() {
       SerialPortServerTransport transport =
-          SerialPortServerTransport.create(cfg -> cfg.setSerialPort(port));
+          SerialPortServerTransport.create(cfg -> cfg.setSerialPort(BOGUS_UNIX_PORT));
 
       ModbusException ex = assertThrows(ModbusException.class, transport::getSerialPort);
-      assertTrue(ex.getMessage().contains(port));
+      assertTrue(ex.getMessage().contains(BOGUS_UNIX_PORT));
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void getSerialPortSucceedsOnWindows() {
+      SerialPortServerTransport transport =
+          SerialPortServerTransport.create(cfg -> cfg.setSerialPort(BOGUS_WINDOWS_PORT));
+
+      assertDoesNotThrow(transport::getSerialPort);
     }
 
     @Test

--- a/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/SerialPortGetCommPortBehaviorTest.java
+++ b/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/SerialPortGetCommPortBehaviorTest.java
@@ -1,0 +1,136 @@
+package com.digitalpetri.modbus.serial;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.digitalpetri.modbus.exceptions.ModbusConnectException;
+import com.digitalpetri.modbus.exceptions.ModbusException;
+import com.digitalpetri.modbus.serial.client.SerialPortClientTransport;
+import com.digitalpetri.modbus.serial.server.SerialPortServerTransport;
+import com.fazecast.jSerialComm.SerialPort;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Tests documenting the behavior of {@link SerialPort#getCommPort(String)} with non-existent ports
+ * and how the serial transport classes handle it.
+ *
+ * <p>The behavior of {@code getCommPort} differs by platform:
+ *
+ * <ul>
+ *   <li><b>Linux/macOS:</b> validates that the port descriptor exists on the filesystem (checking
+ *       the path as-is, then with a {@code /dev/} prefix). Throws {@code
+ *       SerialPortInvalidPortException} immediately if the file does not exist.
+ *   <li><b>Windows:</b> does <em>not</em> check file existence — rewrites the descriptor to {@code
+ *       \\.\COMx} format and defers validation to the native {@code retrievePortDetails()} call,
+ *       which throws {@code SerialPortInvalidPortException} for invalid COM ports.
+ * </ul>
+ *
+ * <p>In both cases the result is the same: {@code getCommPort} throws for non-existent ports. The
+ * transport classes defer this call to connect/bind time so the exception can be caught and wrapped
+ * as a {@link ModbusConnectException}.
+ */
+class SerialPortGetCommPortBehaviorTest {
+
+  private static final String BOGUS_UNIX_PORT = "/dev/this_port_does_not_exist_xyz";
+  private static final String BOGUS_WINDOWS_PORT = "COM999";
+
+  @Nested
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  class GetCommPortOnLinuxMac {
+
+    @Test
+    void getCommPortThrowsForNonExistentPortFile() {
+      // On Linux/Mac, getCommPort checks File.exists() for the port descriptor.
+      // A path that doesn't exist on the filesystem causes an immediate exception.
+      assertThrows(RuntimeException.class, () -> SerialPort.getCommPort(BOGUS_UNIX_PORT));
+    }
+  }
+
+  @Nested
+  @EnabledOnOs(OS.WINDOWS)
+  class GetCommPortOnWindows {
+
+    @Test
+    void getCommPortThrowsForInvalidComPort() {
+      // On Windows, getCommPort rewrites the descriptor to \\.\COMx format
+      // without checking file existence. The native retrievePortDetails() call
+      // throws for COM ports that don't exist.
+      assertThrows(RuntimeException.class, () -> SerialPort.getCommPort(BOGUS_WINDOWS_PORT));
+    }
+  }
+
+  @Nested
+  class ClientTransport {
+
+    @Test
+    void constructorDoesNotCallGetCommPort() {
+      // Construction must always succeed regardless of port name.
+      // getCommPort is deferred to getSerialPort()/connect().
+      assertDoesNotThrow(
+          () -> SerialPortClientTransport.create(cfg -> cfg.setSerialPort(BOGUS_UNIX_PORT)));
+    }
+
+    @Test
+    void getSerialPortWrapsExceptionAsModbusException() {
+      String port = isWindows() ? BOGUS_WINDOWS_PORT : BOGUS_UNIX_PORT;
+      SerialPortClientTransport transport =
+          SerialPortClientTransport.create(cfg -> cfg.setSerialPort(port));
+
+      ModbusException ex = assertThrows(ModbusException.class, transport::getSerialPort);
+      assertTrue(ex.getMessage().contains(port));
+    }
+
+    @Test
+    void connectFailsWithModbusConnectException() {
+      String port = isWindows() ? BOGUS_WINDOWS_PORT : BOGUS_UNIX_PORT;
+      SerialPortClientTransport transport =
+          SerialPortClientTransport.create(cfg -> cfg.setSerialPort(port));
+
+      CompletableFuture<Void> future = transport.connect();
+      ExecutionException ex = assertThrows(ExecutionException.class, future::get);
+      assertInstanceOf(ModbusConnectException.class, ex.getCause());
+    }
+  }
+
+  @Nested
+  class ServerTransport {
+
+    @Test
+    void constructorDoesNotCallGetCommPort() {
+      assertDoesNotThrow(
+          () -> SerialPortServerTransport.create(cfg -> cfg.setSerialPort(BOGUS_UNIX_PORT)));
+    }
+
+    @Test
+    void getSerialPortWrapsExceptionAsModbusException() {
+      String port = isWindows() ? BOGUS_WINDOWS_PORT : BOGUS_UNIX_PORT;
+      SerialPortServerTransport transport =
+          SerialPortServerTransport.create(cfg -> cfg.setSerialPort(port));
+
+      ModbusException ex = assertThrows(ModbusException.class, transport::getSerialPort);
+      assertTrue(ex.getMessage().contains(port));
+    }
+
+    @Test
+    void bindFailsWithModbusConnectException() {
+      String port = isWindows() ? BOGUS_WINDOWS_PORT : BOGUS_UNIX_PORT;
+      SerialPortServerTransport transport =
+          SerialPortServerTransport.create(cfg -> cfg.setSerialPort(port));
+
+      CompletableFuture<Void> future = transport.bind().toCompletableFuture();
+      ExecutionException ex = assertThrows(ExecutionException.class, future::get);
+      assertInstanceOf(ModbusConnectException.class, ex.getCause());
+    }
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name", "").toLowerCase().contains("win");
+  }
+}

--- a/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/SerialPortGetCommPortBehaviorTest.java
+++ b/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/SerialPortGetCommPortBehaviorTest.java
@@ -12,6 +12,7 @@ import com.digitalpetri.modbus.exceptions.ModbusException;
 import com.digitalpetri.modbus.serial.client.SerialPortClientTransport;
 import com.digitalpetri.modbus.serial.server.SerialPortServerTransport;
 import com.fazecast.jSerialComm.SerialPort;
+import com.fazecast.jSerialComm.SerialPortInvalidPortException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Nested;
@@ -53,14 +54,14 @@ class SerialPortGetCommPortBehaviorTest {
     void getCommPortThrowsForNonExistentPortFile() {
       // On Linux/Mac, getCommPort checks File.exists() for the port descriptor.
       // A path that doesn't exist on the filesystem causes an immediate exception.
-      assertThrows(RuntimeException.class, () -> SerialPort.getCommPort(BOGUS_UNIX_PORT));
+      assertThrows(SerialPortInvalidPortException.class, () -> SerialPort.getCommPort(BOGUS_UNIX_PORT));
     }
 
     @Test
     void getCommPortThrowsForWindowsStyleDescriptor() {
       // A Windows-style descriptor like "COM999" also fails on Linux/Mac because
       // it doesn't exist on the filesystem (not under /dev/ either).
-      assertThrows(RuntimeException.class, () -> SerialPort.getCommPort(BOGUS_WINDOWS_PORT));
+      assertThrows(SerialPortInvalidPortException.class, () -> SerialPort.getCommPort(BOGUS_WINDOWS_PORT));
     }
   }
 


### PR DESCRIPTION
## Summary

- **Defer `SerialPort.getCommPort()` from constructor to connect/bind time** using double-checked locking. Previously, the `SerialPort` was eagerly created in the constructor, which on Linux/macOS throws immediately for non-existent port descriptors (since jSerialComm validates the filesystem path). This made it impossible to catch and handle the error as a `ModbusConnectException`. On Windows, `getCommPort()` never validates — failure is deferred to `openPort()` — so the eager call silently succeeded but the behavior was inconsistent across platforms.
- **Wrap errors in proper exception types** — `getCommPort` failures are now caught and surfaced as `ModbusException`, and connect/bind failures (both from `getCommPort` and `openPort`) are wrapped as `ModbusConnectException`. Previously these were generic `Exception` instances.
- **Add comprehensive cross-platform tests** documenting the platform-specific `getCommPort` behavior and verifying that both client and server transports handle bogus port names correctly on all OSes.
- **Expand CI matrix** to build and test on Ubuntu, macOS, and Windows, since the new OS-specific tests exercise platform-dependent behavior.

## Motivation

`SerialPort.getCommPort(String)` behaves differently by platform:
- **Linux/macOS:** Validates that the port descriptor exists on the filesystem. Throws `SerialPortInvalidPortException` immediately if the file does not exist.
- **Windows:** Rewrites the descriptor to `\\.\COMx` format without validation. The `SerialPort` object is created successfully; failure is deferred to `openPort()`, which returns `false`.

By deferring `getCommPort` to connect/bind time, the transport classes can catch the exception on Linux/macOS and wrap it as a `ModbusConnectException`, giving callers a consistent error-handling experience across all platforms.

## Test plan

- [x] `SerialPortGetCommPortBehaviorTest` — OS-gated tests document raw `getCommPort` behavior on each platform
- [x] `ClientTransport` / `ServerTransport` nested tests verify constructor never calls `getCommPort`, and that connect/bind with bogus ports fails with `ModbusConnectException`
- [x] CI runs on ubuntu-latest, macos-latest, and windows-latest
