### PR TITLE
Add RS-485 configuration parameters for serial transports

### DIFF
--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/SerialPortTransportConfig.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/SerialPortTransportConfig.java
@@ -15,6 +15,16 @@ import java.util.function.Consumer;
  * @param stopBits the number of stop bits to use.
  * @param parity the type of parity error-checking to use.
  * @param rs485Mode enable RS-485 mode, i.e. transmit/receive mode signaling using the RTS pin.
+ * @param rs485RtsActiveHigh whether to set the RTS line to 1 when transmitting. Effective only on
+ *     Linux.
+ * @param rs485Termination whether to enable RS-485 bus termination, on systems that support this
+ *     feature. Effective only on Linux.
+ * @param rs485RxDuringTx whether to receive data while transmitting. This usually means that data
+ *     sent will be read back. Effective only on Linux.
+ * @param rs485DelayBefore the time to wait in microseconds after enabling transmit mode before
+ *     sending the first data bit. Effective only on Linux.
+ * @param rs485DelayAfter the time to wait in microseconds after sending the last data bit before
+ *     disabling transmit mode. Effective only on Linux.
  * @param executor the {@link ExecutorService} to use when delivering frame received callbacks.
  * @see SerialPortTransportConfig#create(Consumer)
  */
@@ -25,6 +35,11 @@ public record SerialPortTransportConfig(
     int stopBits,
     int parity,
     boolean rs485Mode,
+    boolean rs485RtsActiveHigh,
+    boolean rs485Termination,
+    boolean rs485RxDuringTx,
+    int rs485DelayBefore,
+    int rs485DelayAfter,
     ExecutorService executor) {
 
   /**
@@ -77,11 +92,49 @@ public record SerialPortTransportConfig(
     public int parity = SerialPort.NO_PARITY;
 
     /**
-     * Enable RS-485 mode, i.e. transmit/receive mode signaling using the RTS pin.
+     * Enable RS-485 mode, i.e., transmit/receive mode signaling using the RTS pin.
      *
      * <p>This requires support from the underlying driver and may not work with all RS-485 devices.
      */
     public boolean rs485Mode = false;
+
+    /**
+     * Whether to set the RTS line to 1 when transmitting.
+     *
+     * <p>Effective only on Linux.
+     */
+    public boolean rs485RtsActiveHigh = true;
+
+    /**
+     * Whether to enable RS-485 bus termination on systems that support this feature.
+     *
+     * <p>Effective only on Linux.
+     */
+    public boolean rs485Termination = false;
+
+    /**
+     * Whether to receive data while transmitting. This usually means that data sent will be read
+     * back.
+     *
+     * <p>Effective only on Linux.
+     */
+    public boolean rs485RxDuringTx = false;
+
+    /**
+     * The time to wait in microseconds after enabling transmit mode before sending the first data
+     * bit.
+     *
+     * <p>Effective only on Linux.
+     */
+    public int rs485DelayBefore = 0;
+
+    /**
+     * The time to wait in microseconds after sending the last data bit before disabling transmit
+     * mode.
+     *
+     * <p>Effective only on Linux.
+     */
+    public int rs485DelayAfter = 0;
 
     /**
      * The {@link ExecutorService} to use when delivering frame received callbacks.
@@ -165,6 +218,74 @@ public record SerialPortTransportConfig(
     }
 
     /**
+     * Set whether to set the RTS line to 1 when transmitting.
+     *
+     * <p>Effective only on Linux.
+     *
+     * @param rs485RtsActiveHigh true to set the RTS line to 1 when transmitting.
+     * @return this {@link Builder}.
+     */
+    public Builder setRs485RtsActiveHigh(boolean rs485RtsActiveHigh) {
+      this.rs485RtsActiveHigh = rs485RtsActiveHigh;
+      return this;
+    }
+
+    /**
+     * Set whether to enable RS-485 bus termination on systems that support this feature.
+     *
+     * <p>Effective only on Linux.
+     *
+     * @param rs485Termination true to enable bus termination.
+     * @return this {@link Builder}.
+     */
+    public Builder setRs485Termination(boolean rs485Termination) {
+      this.rs485Termination = rs485Termination;
+      return this;
+    }
+
+    /**
+     * Set whether to receive data while transmitting. This usually means that data sent will be
+     * read back.
+     *
+     * <p>Effective only on Linux.
+     *
+     * @param rs485RxDuringTx true to receive data while transmitting.
+     * @return this {@link Builder}.
+     */
+    public Builder setRs485RxDuringTx(boolean rs485RxDuringTx) {
+      this.rs485RxDuringTx = rs485RxDuringTx;
+      return this;
+    }
+
+    /**
+     * Set the time to wait in microseconds after enabling transmit mode before sending the first
+     * data bit.
+     *
+     * <p>Effective only on Linux.
+     *
+     * @param rs485DelayBefore the delay in microseconds before sending.
+     * @return this {@link Builder}.
+     */
+    public Builder setRs485DelayBefore(int rs485DelayBefore) {
+      this.rs485DelayBefore = rs485DelayBefore;
+      return this;
+    }
+
+    /**
+     * Set the time to wait in microseconds after sending the last data bit before disabling
+     * transmit mode.
+     *
+     * <p>Effective only on Linux.
+     *
+     * @param rs485DelayAfter the delay in microseconds after sending.
+     * @return this {@link Builder}.
+     */
+    public Builder setRs485DelayAfter(int rs485DelayAfter) {
+      this.rs485DelayAfter = rs485DelayAfter;
+      return this;
+    }
+
+    /**
      * Set the {@link ExecutorService} to use when delivering frame received callbacks.
      *
      * @param executor the executor service.
@@ -189,7 +310,18 @@ public record SerialPortTransportConfig(
       }
 
       return new SerialPortTransportConfig(
-          serialPort, baudRate, dataBits, stopBits, parity, rs485Mode, executor);
+          serialPort,
+          baudRate,
+          dataBits,
+          stopBits,
+          parity,
+          rs485Mode,
+          rs485RtsActiveHigh,
+          rs485Termination,
+          rs485RxDuringTx,
+          rs485DelayBefore,
+          rs485DelayAfter,
+          executor);
     }
   }
 }

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/client/SerialPortClientTransport.java
@@ -55,12 +55,24 @@ public class SerialPortClientTransport implements ModbusRtuClientTransport {
         if (sp == null) {
           try {
             sp = SerialPort.getCommPort(config.serialPort());
+
             sp.setComPortParameters(
                 config.baudRate(),
                 config.dataBits(),
                 config.stopBits(),
                 config.parity(),
                 config.rs485Mode());
+
+            if (config.rs485Mode()) {
+              sp.setRs485ModeParameters(
+                  true,
+                  config.rs485RtsActiveHigh(),
+                  config.rs485Termination(),
+                  config.rs485RxDuringTx(),
+                  config.rs485DelayBefore(),
+                  config.rs485DelayAfter());
+            }
+
             this.serialPort = sp;
           } catch (Exception e) {
             throw new ModbusException(

--- a/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/server/SerialPortServerTransport.java
+++ b/modbus-serial/src/main/java/com/digitalpetri/modbus/serial/server/SerialPortServerTransport.java
@@ -63,12 +63,24 @@ public class SerialPortServerTransport implements ModbusRtuServerTransport {
         if (sp == null) {
           try {
             sp = SerialPort.getCommPort(config.serialPort());
+
             sp.setComPortParameters(
                 config.baudRate(),
                 config.dataBits(),
                 config.stopBits(),
                 config.parity(),
                 config.rs485Mode());
+
+            if (config.rs485Mode()) {
+              sp.setRs485ModeParameters(
+                  true,
+                  config.rs485RtsActiveHigh(),
+                  config.rs485Termination(),
+                  config.rs485RxDuringTx(),
+                  config.rs485DelayBefore(),
+                  config.rs485DelayAfter());
+            }
+
             this.serialPort = sp;
           } catch (Exception e) {
             throw new ModbusException(

--- a/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/Rs485ConfigTest.java
+++ b/modbus-serial/src/test/java/com/digitalpetri/modbus/serial/Rs485ConfigTest.java
@@ -1,0 +1,172 @@
+package com.digitalpetri.modbus.serial;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.digitalpetri.modbus.serial.client.SerialPortClientTransport;
+import com.digitalpetri.modbus.serial.server.SerialPortServerTransport;
+import com.fazecast.jSerialComm.SerialPort;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class Rs485ConfigTest {
+
+  @Nested
+  class ConfigDefaults {
+
+    @Test
+    void defaultRs485Parameters() {
+      var config = SerialPortTransportConfig.create(cfg -> cfg.setSerialPort("/dev/tty"));
+
+      assertFalse(config.rs485Mode());
+      assertTrue(config.rs485RtsActiveHigh());
+      assertFalse(config.rs485Termination());
+      assertFalse(config.rs485RxDuringTx());
+      assertEquals(0, config.rs485DelayBefore());
+      assertEquals(0, config.rs485DelayAfter());
+    }
+  }
+
+  @Nested
+  class ConfigCustomValues {
+
+    @Test
+    void customRs485Parameters() {
+      var config =
+          SerialPortTransportConfig.create(
+              cfg -> {
+                cfg.setSerialPort("/dev/tty");
+                cfg.setRs485Mode(true);
+                cfg.setRs485RtsActiveHigh(false);
+                cfg.setRs485Termination(true);
+                cfg.setRs485RxDuringTx(true);
+                cfg.setRs485DelayBefore(100);
+                cfg.setRs485DelayAfter(200);
+              });
+
+      assertTrue(config.rs485Mode());
+      assertFalse(config.rs485RtsActiveHigh());
+      assertTrue(config.rs485Termination());
+      assertTrue(config.rs485RxDuringTx());
+      assertEquals(100, config.rs485DelayBefore());
+      assertEquals(200, config.rs485DelayAfter());
+    }
+  }
+
+  /**
+   * Tests that verify the RS-485 parameters are applied to the {@link SerialPort} when RS-485 mode
+   * is enabled in the transport configuration.
+   *
+   * <p>Uses reflection to inspect jSerialComm's private RS-485 fields since no public getters are
+   * available.
+   */
+  @Nested
+  class TransportRs485 {
+
+    private static final String TEST_PORT = isWindows() ? "COM1" : "/dev/tty";
+
+    @Test
+    void clientTransportSetsRs485Parameters() throws Exception {
+      var transport =
+          SerialPortClientTransport.create(
+              cfg -> {
+                cfg.setSerialPort(TEST_PORT);
+                cfg.setRs485Mode(true);
+                cfg.setRs485RtsActiveHigh(false);
+                cfg.setRs485Termination(true);
+                cfg.setRs485RxDuringTx(true);
+                cfg.setRs485DelayBefore(100);
+                cfg.setRs485DelayAfter(200);
+              });
+
+      SerialPort sp = transport.getSerialPort();
+      assertRs485Fields(sp, true, false, true, true, 100, 200);
+    }
+
+    @Test
+    void serverTransportSetsRs485Parameters() throws Exception {
+      var transport =
+          SerialPortServerTransport.create(
+              cfg -> {
+                cfg.setSerialPort(TEST_PORT);
+                cfg.setRs485Mode(true);
+                cfg.setRs485RtsActiveHigh(false);
+                cfg.setRs485Termination(true);
+                cfg.setRs485RxDuringTx(true);
+                cfg.setRs485DelayBefore(100);
+                cfg.setRs485DelayAfter(200);
+              });
+
+      SerialPort sp = transport.getSerialPort();
+      assertRs485Fields(sp, true, false, true, true, 100, 200);
+    }
+
+    @Test
+    void clientTransportDoesNotSetRs485WhenDisabled() throws Exception {
+      var transport =
+          SerialPortClientTransport.create(
+              cfg -> {
+                cfg.setSerialPort(TEST_PORT);
+                cfg.setRs485Mode(false);
+                cfg.setRs485RtsActiveHigh(false);
+                cfg.setRs485Termination(true);
+                cfg.setRs485RxDuringTx(true);
+                cfg.setRs485DelayBefore(100);
+                cfg.setRs485DelayAfter(200);
+              });
+
+      SerialPort sp = transport.getSerialPort();
+      // setRs485ModeParameters should NOT be called, so SerialPort fields stay at defaults
+      assertRs485Fields(sp, false, true, false, false, 0, 0);
+    }
+
+    @Test
+    void serverTransportDoesNotSetRs485WhenDisabled() throws Exception {
+      var transport =
+          SerialPortServerTransport.create(
+              cfg -> {
+                cfg.setSerialPort(TEST_PORT);
+                cfg.setRs485Mode(false);
+                cfg.setRs485RtsActiveHigh(false);
+                cfg.setRs485Termination(true);
+                cfg.setRs485RxDuringTx(true);
+                cfg.setRs485DelayBefore(100);
+                cfg.setRs485DelayAfter(200);
+              });
+
+      SerialPort sp = transport.getSerialPort();
+      assertRs485Fields(sp, false, true, false, false, 0, 0);
+    }
+
+    private static void assertRs485Fields(
+        SerialPort sp,
+        boolean expectedMode,
+        boolean expectedActiveHigh,
+        boolean expectedTermination,
+        boolean expectedRxDuringTx,
+        int expectedDelayBefore,
+        int expectedDelayAfter)
+        throws Exception {
+
+      assertEquals(expectedMode, getField(sp, "rs485Mode"), "rs485Mode");
+      assertEquals(expectedActiveHigh, getField(sp, "rs485ActiveHigh"), "rs485ActiveHigh");
+      assertEquals(
+          expectedTermination, getField(sp, "rs485EnableTermination"), "rs485EnableTermination");
+      assertEquals(expectedRxDuringTx, getField(sp, "rs485RxDuringTx"), "rs485RxDuringTx");
+      assertEquals(expectedDelayBefore, getField(sp, "rs485DelayBefore"), "rs485DelayBefore");
+      assertEquals(expectedDelayAfter, getField(sp, "rs485DelayAfter"), "rs485DelayAfter");
+    }
+
+    private static Object getField(SerialPort sp, String fieldName) throws Exception {
+      Field field = SerialPort.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.get(sp);
+    }
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name", "").toLowerCase().contains("win");
+  }
+}


### PR DESCRIPTION
## Summary

- Add `rtsActiveHigh`, `termination`, `rxDuringTx`, `delayBefore`, and `delayAfter` fields to `SerialPortTransportConfig` for fine-grained RS-485 control (Linux `setRs485ModeParameters`)
- When `rs485Mode` is enabled, both client and server transports now call `setRs485ModeParameters()` with the configured values
- Include builder methods, Javadoc, and a test for default/custom RS-485 configuration

## Test plan

- [x] `Rs485ConfigTest` verifies default values and custom builder configuration
- [ ] Manual verification on Linux with an RS-485 adapter