### PR TITLE
Bump dependency and plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,30 +49,30 @@
 
     <!-- Dependencies -->
     <jserialcomm.version>2.11.4</jserialcomm.version>
-    <netty.version>4.1.131.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <netty-channel-fsm.version>1.0.2</netty-channel-fsm.version>
-    <slf4j.version>2.0.17</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
 
     <!-- Test Dependencies -->
-    <bouncycastle.version>1.83</bouncycastle.version>
-    <junit.version>5.14.3</junit.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
+    <junit.version>5.14.4</junit.version>
 
     <!-- Plugin Dependencies -->
-    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <checkstyle.version>11.1.0</checkstyle.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
-    <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
+    <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-    <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Summary

Routine Maven dependency and build-plugin version updates, sourced from `versions:display-dependency-updates` and `versions:display-plugin-updates`. All bumps are stable releases (no pre-release/snapshot versions), and all are patch/minor except the Spotless plugin. Versions are managed centrally as properties in the root `pom.xml`.

## Dependencies

| Artifact | From | To |
|---|---|---|
| io.netty (netty-buffer/codec/handler) | 4.1.131.Final | 4.1.135.Final |
| org.slf4j (slf4j-api/slf4j-simple) | 2.0.17 | 2.0.18 |
| org.junit.jupiter (junit-jupiter-api/engine) | 5.14.3 | 5.14.4 |
| org.bouncycastle (bcpkix/bcprov-jdk18on) | 1.83 | 1.84 |

## Build Plugins

| Plugin | From | To |
|---|---|---|
| spotless-maven-plugin | 3.2.1 | 3.8.0 |
| maven-dependency-plugin | 3.10.0 | 3.11.0 |
| maven-enforcer-plugin | 3.6.2 | 3.6.3 |
| maven-resources-plugin | 3.4.0 | 3.5.0 |
| central-publishing-maven-plugin | 0.10.0 | 0.11.0 |

> **Note:** Spotless jumps several minor versions (3.2.1 → 3.8.0). `mvn clean verify` ran the Spotless check and reported all files already clean — no formatting changes were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)