### PR TITLE
Update Maven dependencies (2026-07-21)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
 
     <!-- Dependencies -->
     <jserialcomm.version>2.11.4</jserialcomm.version>
-    <netty.version>4.1.135.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <netty-channel-fsm.version>1.0.2</netty-channel-fsm.version>
     <slf4j.version>2.0.18</slf4j.version>
 
     <!-- Test Dependencies -->
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <junit.version>5.14.4</junit.version>
 
     <!-- Plugin Dependencies -->


### PR DESCRIPTION
## Updates

### Dependencies

- `io.netty:netty-buffer`, `io.netty:netty-codec`, and `io.netty:netty-handler`: `4.1.135.Final` → `4.1.136.Final` (via `netty.version`)
- `org.bouncycastle:bcpkix-jdk18on` and `org.bouncycastle:bcprov-jdk18on`: `1.84` → `1.85` (via `bouncycastle.version`)

### Plugins

- No plugin updates were available.

## Skipped updates

- No prerelease or other non-stable updates were reported.
- The existing Versions Maven Plugin rule continues to keep Netty on the compatible 4.1 release line.

## Verification

- `mvn versions:display-dependency-updates` — passed
- `mvn versions:display-plugin-updates` — passed
- `mvn dependency:resolve` — passed after installing the reactor-local `2.1.6-SNAPSHOT` artifacts; the initial run could not resolve the sibling `modbus` module from the local repository
- `mvn -q spotless:apply` — passed; no tracked formatting changes
- `mvn -q clean compile` — passed
- `mvn -q clean verify` — passed; 80 tests, 0 failures, 0 errors, 0 skipped
- Independent code review — `APPROVED`
