### PR TITLE
Update Maven dependencies (2026-07-27)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>


### PR DESCRIPTION
## Updated dependencies and plugins

### Dependencies

No stable dependency updates were reported.

### Plugins

- `org.apache.maven.plugins:maven-jar-plugin`: `3.5.0` -> `3.5.1`

## Skipped prerelease/non-stable suggestions

None reported.

## Verification

All Maven commands were run through the `maven-command-runner` agent.

- `mvn versions:display-dependency-updates`: passed; no dependency updates reported
- `mvn versions:display-plugin-updates`: passed; reported `maven-jar-plugin` `3.5.0` -> `3.5.1`
- `mvn -q -DskipTests install`: passed
- `mvn dependency:resolve`: passed
- `mvn -q spotless:apply`: passed; no additional file changes
- `mvn -q clean compile`: passed
- `mvn -q clean verify`: passed

Review: APPROVED by subagent.
