### PR TITLE
Update Maven dependencies (2026-08-03)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-    <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Updates

### Plugins
- `com.diffplug.spotless:spotless-maven-plugin`: `3.8.0` -> `3.9.0`

### Dependencies
- None; dependency update report found no newer dependency versions.

### Skipped prerelease/non-stable suggestions
- None reported. The repository versions-maven-plugin rules continue to ignore prerelease versions and Netty 4.2+ updates.

## Verification

- `mvn versions:display-dependency-updates` - passed; no dependency updates found.
- `mvn versions:display-plugin-updates` - passed; found Spotless Maven Plugin `3.8.0` -> `3.9.0`.
- `mvn -q -DskipTests install` - passed.
- `mvn dependency:resolve` - passed for all reactor modules.
- `mvn -q spotless:apply` - passed.
- `mvn -q clean compile` - passed.
- `mvn -q clean verify` - passed.

Review: APPROVED.