### PR TITLE
Fix Crc16.update(ByteBuffer) reading past limit for positioned buffers

### DIFF
--- a/modbus/src/main/java/com/digitalpetri/modbus/Crc16.java
+++ b/modbus/src/main/java/com/digitalpetri/modbus/Crc16.java
@@ -71,7 +71,7 @@ public class Crc16 {
   public void update(ByteBuffer buffer) {
     int offset = buffer.position();
     for (int i = offset; i < buffer.limit(); i++) {
-      update(buffer.get(offset + i));
+      update(buffer.get(i));
     }
   }
 }

--- a/modbus/src/test/java/com/digitalpetri/modbus/Crc16Test.java
+++ b/modbus/src/test/java/com/digitalpetri/modbus/Crc16Test.java
@@ -18,6 +18,19 @@ class Crc16Test {
   }
 
   @Test
+  void crc16WithBufferPosition() {
+    // A buffer whose position is advanced past leading bytes must be CRC'd
+    // over only the remaining bytes [position, limit). Prefixing the known
+    // vector with two bytes and skipping them must yield the same CRC. See #157.
+    Crc16 crc = new Crc16();
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[] {0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x09});
+    buffer.position(2);
+    crc.update(buffer);
+
+    assertEquals(0x2590, crc.getValue());
+  }
+
+  @Test
   void reset() {
     Crc16 crc = new Crc16();
     crc.update(ByteBuffer.wrap(new byte[] {0x12, 0x34, 0x56, 0x78, 0x09}));


### PR DESCRIPTION
### Summary

Fixes #157. `Crc16.update(ByteBuffer)` throws `IndexOutOfBoundsException` for any buffer whose position is non-zero.

### Root cause

```java
int offset = buffer.position();
for (int i = offset; i < buffer.limit(); i++) {
  update(buffer.get(offset + i));   // offset added twice
}
```

`i` already starts at `offset` (the position), so `buffer.get(offset + i)` reads the buffer at doubled indices. When `offset > 0`, `offset + i` runs off the end and `ByteBuffer.get(int)` throws once the index reaches `limit()`. The bug is masked only when `position() == 0` (`offset + i == i`), which is why the existing callers that pass position-0 buffers were unaffected.

### Fix

Index each absolute position `i` in `[position, limit)` exactly once:

```java
int offset = buffer.position();
for (int i = offset; i < buffer.limit(); i++) {
  update(buffer.get(i));
}
```

This matches the method's documented contract of CRC-ing the buffer's remaining bytes and does not advance the buffer position (absolute `get`).

### Test

Added `Crc16Test.crc16WithBufferPosition`, which prefixes the existing known CRC vector with two bytes and advances `position` past them; the CRC over the remaining bytes must equal the same known value (`0x2590`).

- Before the fix: `IndexOutOfBoundsException` at `Crc16.java`.
- After the fix: passes.

### Verification

- `mvn -pl modbus test` — 79 tests, 0 failures/errors (the RTU frame accumulator paths that CRC positioned buffers are covered).
- `mvn -pl modbus checkstyle:check` — 0 violations.
- `mvn -pl modbus spotless:check` — clean.

---

Disclosure: this fix was prepared with AI assistance (Claude). I have reviewed it and verified the reasoning, the red-green test, and the full module build myself.
