### PR TITLE
Validate process image read request ranges

### DIFF
--- a/modbus/src/main/java/com/digitalpetri/modbus/server/ReadOnlyModbusServices.java
+++ b/modbus/src/main/java/com/digitalpetri/modbus/server/ReadOnlyModbusServices.java
@@ -1,5 +1,6 @@
 package com.digitalpetri.modbus.server;
 
+import com.digitalpetri.modbus.exceptions.ModbusResponseException;
 import com.digitalpetri.modbus.exceptions.UnknownUnitIdException;
 import com.digitalpetri.modbus.pdu.ReadCoilsRequest;
 import com.digitalpetri.modbus.pdu.ReadCoilsResponse;
@@ -20,7 +21,9 @@ public abstract class ReadOnlyModbusServices implements ModbusServices {
   @Override
   public ReadCoilsResponse readCoils(
       ModbusRequestContext context, int unitId, ReadCoilsRequest request)
-      throws UnknownUnitIdException {
+      throws ModbusResponseException, UnknownUnitIdException {
+
+    ModbusServices.checkBitRange(request.getFunctionCode(), request.address(), request.quantity());
 
     ProcessImage processImage =
         getProcessImage(unitId).orElseThrow(() -> new UnknownUnitIdException(unitId));
@@ -36,7 +39,9 @@ public abstract class ReadOnlyModbusServices implements ModbusServices {
   @Override
   public ReadDiscreteInputsResponse readDiscreteInputs(
       ModbusRequestContext context, int unitId, ReadDiscreteInputsRequest request)
-      throws UnknownUnitIdException {
+      throws ModbusResponseException, UnknownUnitIdException {
+
+    ModbusServices.checkBitRange(request.getFunctionCode(), request.address(), request.quantity());
 
     ProcessImage processImage =
         getProcessImage(unitId).orElseThrow(() -> new UnknownUnitIdException(unitId));
@@ -52,7 +57,10 @@ public abstract class ReadOnlyModbusServices implements ModbusServices {
   @Override
   public ReadHoldingRegistersResponse readHoldingRegisters(
       ModbusRequestContext context, int unitId, ReadHoldingRegistersRequest request)
-      throws UnknownUnitIdException {
+      throws ModbusResponseException, UnknownUnitIdException {
+
+    ModbusServices.checkRegisterRange(
+        request.getFunctionCode(), request.address(), request.quantity());
 
     ProcessImage processImage =
         getProcessImage(unitId).orElseThrow(() -> new UnknownUnitIdException(unitId));
@@ -69,7 +77,10 @@ public abstract class ReadOnlyModbusServices implements ModbusServices {
   @Override
   public ReadInputRegistersResponse readInputRegisters(
       ModbusRequestContext context, int unitId, ReadInputRegistersRequest request)
-      throws UnknownUnitIdException {
+      throws ModbusResponseException, UnknownUnitIdException {
+
+    ModbusServices.checkRegisterRange(
+        request.getFunctionCode(), request.address(), request.quantity());
 
     ProcessImage processImage =
         getProcessImage(unitId).orElseThrow(() -> new UnknownUnitIdException(unitId));

--- a/modbus/src/test/java/com/digitalpetri/modbus/server/ReadOnlyModbusServicesTest.java
+++ b/modbus/src/test/java/com/digitalpetri/modbus/server/ReadOnlyModbusServicesTest.java
@@ -1,7 +1,12 @@
 package com.digitalpetri.modbus.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.digitalpetri.modbus.ExceptionCode;
+import com.digitalpetri.modbus.FunctionCode;
+import com.digitalpetri.modbus.exceptions.ModbusResponseException;
+import com.digitalpetri.modbus.exceptions.UnknownUnitIdException;
 import com.digitalpetri.modbus.pdu.ReadCoilsRequest;
 import com.digitalpetri.modbus.pdu.ReadCoilsResponse;
 import com.digitalpetri.modbus.pdu.ReadDiscreteInputsRequest;
@@ -15,6 +20,7 @@ import java.net.SocketAddress;
 import java.util.Optional;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class ReadOnlyModbusServicesTest {
 
@@ -204,6 +210,99 @@ public class ReadOnlyModbusServicesTest {
       remaining -= quantity;
       quantity = Math.min(remaining, random.nextInt(125) + 1);
     }
+  }
+
+  @Test
+  void readCoilsValidatesRange() throws Exception {
+    assertBitRangeValidation(
+        FunctionCode.READ_COILS,
+        (address, quantity) ->
+            services
+                .readCoils(
+                    new TestModbusRequestContext(), 0, new ReadCoilsRequest(address, quantity))
+                .coils()
+                .length);
+  }
+
+  @Test
+  void readDiscreteInputsValidatesRange() throws Exception {
+    assertBitRangeValidation(
+        FunctionCode.READ_DISCRETE_INPUTS,
+        (address, quantity) ->
+            services
+                .readDiscreteInputs(
+                    new TestModbusRequestContext(),
+                    0,
+                    new ReadDiscreteInputsRequest(address, quantity))
+                .inputs()
+                .length);
+  }
+
+  @Test
+  void readHoldingRegistersValidatesRange() throws Exception {
+    assertRegisterRangeValidation(
+        FunctionCode.READ_HOLDING_REGISTERS,
+        (address, quantity) ->
+            services
+                .readHoldingRegisters(
+                    new TestModbusRequestContext(),
+                    0,
+                    new ReadHoldingRegistersRequest(address, quantity))
+                .registers()
+                .length);
+  }
+
+  @Test
+  void readInputRegistersValidatesRange() throws Exception {
+    assertRegisterRangeValidation(
+        FunctionCode.READ_INPUT_REGISTERS,
+        (address, quantity) ->
+            services
+                .readInputRegisters(
+                    new TestModbusRequestContext(),
+                    0,
+                    new ReadInputRegistersRequest(address, quantity))
+                .registers()
+                .length);
+  }
+
+  private static void assertBitRangeValidation(FunctionCode functionCode, ReadOperation operation)
+      throws Exception {
+
+    assertEquals(250, operation.read(0, 2000));
+    assertModbusResponseException(
+        functionCode, ExceptionCode.ILLEGAL_DATA_VALUE, () -> operation.read(0, 0));
+    assertModbusResponseException(
+        functionCode, ExceptionCode.ILLEGAL_DATA_VALUE, () -> operation.read(0, 2001));
+    assertModbusResponseException(
+        functionCode, ExceptionCode.ILLEGAL_DATA_ADDRESS, () -> operation.read(0xFFFF, 2));
+  }
+
+  private static void assertRegisterRangeValidation(
+      FunctionCode functionCode, ReadOperation operation) throws Exception {
+
+    assertEquals(250, operation.read(0, 125));
+    assertModbusResponseException(
+        functionCode, ExceptionCode.ILLEGAL_DATA_VALUE, () -> operation.read(0, 0));
+    assertModbusResponseException(
+        functionCode, ExceptionCode.ILLEGAL_DATA_VALUE, () -> operation.read(0, 126));
+    assertModbusResponseException(
+        functionCode, ExceptionCode.ILLEGAL_DATA_ADDRESS, () -> operation.read(0xFFFF, 2));
+  }
+
+  private static void assertModbusResponseException(
+      FunctionCode functionCode, ExceptionCode exceptionCode, Executable executable) {
+
+    ModbusResponseException exception = assertThrows(ModbusResponseException.class, executable);
+
+    assertEquals(functionCode.getCode(), exception.getFunctionCode());
+    assertEquals(exceptionCode.getCode(), exception.getExceptionCode());
+  }
+
+  @FunctionalInterface
+  private interface ReadOperation {
+
+    int read(int address, int quantity) throws ModbusResponseException, UnknownUnitIdException;
   }
 
   static class TestModbusRequestContext implements ModbusTcpRequestContext {


### PR DESCRIPTION
Invalid Modbus read requests could ask for zero items, too many items, or a range past the end of the address space. The built-in process-image services accepted those requests and returned successful responses instead of the protocol-required error.

This change validates read requests before they reach the process image, using the existing range checks to return the appropriate Modbus exception response.

## What changed

- Validate coil and discrete-input read quantities and address ranges.
- Validate holding-register and input-register read quantities and address ranges.
- Apply the checks in `ReadOnlyModbusServices`; `ReadWriteModbusServices` inherits the corrected behavior.
- Add boundary coverage for valid maximums, invalid quantities, and address overruns across all four read function codes.

Closes #158.
