### PR TITLE
Release version 2.1.6

### DIFF
--- a/modbus-serial/pom.xml
+++ b/modbus-serial/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.6</version>
   </parent>
 
   <name>Modbus :: Serial</name>

--- a/modbus-serial/pom.xml
+++ b/modbus-serial/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6</version>
+    <version>2.1.7-SNAPSHOT</version>
   </parent>
 
   <name>Modbus :: Serial</name>

--- a/modbus-tcp/pom.xml
+++ b/modbus-tcp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.6</version>
   </parent>
 
   <name>Modbus :: TCP</name>

--- a/modbus-tcp/pom.xml
+++ b/modbus-tcp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6</version>
+    <version>2.1.7-SNAPSHOT</version>
   </parent>
 
   <name>Modbus :: TCP</name>

--- a/modbus-tests/pom.xml
+++ b/modbus-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.6</version>
   </parent>
 
   <name>Modbus :: Tests</name>

--- a/modbus-tests/pom.xml
+++ b/modbus-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6</version>
+    <version>2.1.7-SNAPSHOT</version>
   </parent>
 
   <name>Modbus :: Tests</name>

--- a/modbus/pom.xml
+++ b/modbus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6</version>
+    <version>2.1.7-SNAPSHOT</version>
   </parent>
 
   <name>Modbus :: Core</name>

--- a/modbus/pom.xml
+++ b/modbus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.digitalpetri.modbus</groupId>
     <artifactId>modbus-parent</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.6</version>
   </parent>
 
   <name>Modbus :: Core</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.digitalpetri.modbus</groupId>
   <artifactId>modbus-parent</artifactId>
-  <version>2.1.6</version>
+  <version>2.1.7-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Modbus</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.digitalpetri.modbus</groupId>
   <artifactId>modbus-parent</artifactId>
-  <version>2.1.6-SNAPSHOT</version>
+  <version>2.1.6</version>
   <packaging>pom</packaging>
 
   <name>Modbus</name>


### PR DESCRIPTION
Publishes v2.1.6 and advances development to 2.1.7-SNAPSHOT.

- Release: https://github.com/digitalpetri/modbus/releases/tag/v2.1.6
- Maven Central deployment: https://github.com/digitalpetri/modbus/actions/runs/31260562338
