### PR TITLE
Update Maven dependencies (2026-08-10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
     <!-- Dependencies -->
     <jserialcomm.version>2.11.4</jserialcomm.version>
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <netty-channel-fsm.version>1.0.2</netty-channel-fsm.version>
     <slf4j.version>2.0.18</slf4j.version>
 


### PR DESCRIPTION
## Updated dependencies

- `io.netty:netty-buffer` `4.1.136.Final` -> `4.1.137.Final`
- `io.netty:netty-codec` `4.1.136.Final` -> `4.1.137.Final`
- `io.netty:netty-handler` `4.1.136.Final` -> `4.1.137.Final`

## Updated plugins

- None. All plugins with specified versions are already current.

## Skipped prerelease/non-stable suggestions

- None reported.

## Skipped resolution failures

- `org.bouncycastle:bcprov-jdk18on` `1.85` -> `1.85.2` was reported, but skipped because the shared `bouncycastle.version` property also controls `org.bouncycastle:bcpkix-jdk18on`, and `bcpkix-jdk18on:1.85.2` does not resolve from Maven Central.

## Verification

All Maven commands were run via the `maven-command-runner` agent.

- `mvn versions:display-dependency-updates` - passed
- `mvn versions:display-plugin-updates` - passed
- `mvn -q -DskipTests install` - failed on the initial Bouncy Castle 1.85.2 attempt, then passed after reverting that specific update
- `mvn dependency:resolve` - passed
- `mvn -q spotless:apply` - passed
- `mvn -q clean compile` - passed
- `mvn -q clean verify` - passed

Independent review: APPROVED.