### PR TITLE
Update Maven dependencies (2026-08-17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-    <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.10.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Updated dependencies and plugins

Plugins:
- `com.diffplug.spotless:spotless-maven-plugin` `3.9.0` -> `3.10.0`

Dependencies:
- None applied.

## Skipped prerelease/non-stable suggestions

No prerelease or non-stable suggestions were reported.

Skipped stable suggestions:
- `org.bouncycastle:bcprov-jdk18on` `1.85` -> `1.85.2` was not applied because the centralized `bouncycastle.version` property also controls `org.bouncycastle:bcpkix-jdk18on`, and `bcpkix-jdk18on:1.85.2` does not resolve from Maven Central.

## Verification

Initial verification with both reported updates:
- `mvn -q -DskipTests install` failed because `org.bouncycastle:bcpkix-jdk18on:jar:1.85.2` was not found in Maven Central.

Verification after reverting only the Bouncy Castle update:
- `mvn -q -DskipTests install` passed
- `mvn dependency:resolve` passed
- `mvn -q spotless:apply` passed
- `mvn -q clean compile` passed
- `mvn -q clean verify` passed

Review:
- Independent Codex review: APPROVED
