### PR TITLE
Update Maven dependencies (2026-08-31)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-    <spotless-maven-plugin.version>3.10.0</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.10.1</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Updates

### Dependencies

- None applied.

### Plugins

- `com.diffplug.spotless:spotless-maven-plugin` `3.10.0` -> `3.10.1`

## Skipped

- `org.bouncycastle:bcprov-jdk18on` `1.85` -> `1.85.2` was reported, but was not applied because the shared `bouncycastle.version` property also controls `org.bouncycastle:bcpkix-jdk18on`, and `bcpkix-jdk18on:1.85.2` is not present in Maven Central.
- No prerelease, milestone, RC, snapshot, or other non-stable suggestions were reported.

## Verification

All Maven commands were run by the maven-command-runner agent.

- `mvn versions:display-dependency-updates` - passed
- `mvn versions:display-plugin-updates` - passed
- `mvn -q -DskipTests install` - passed
- `mvn dependency:resolve` - passed
- `mvn -q spotless:apply` - passed
- `mvn -q clean compile` - passed
- `mvn -q clean verify` - passed

Independent review: APPROVED.

Commit: `d2533af5c31f9530c674e9f5c2c4951c9270e11f`