### PR TITLE
Update Maven dependencies (2026-09-07)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jserialcomm.version>2.11.4</jserialcomm.version>
     <netty.version>4.1.137.Final</netty.version>
     <netty-channel-fsm.version>1.0.2</netty-channel-fsm.version>
-    <slf4j.version>2.0.18</slf4j.version>
+    <slf4j.version>2.0.19</slf4j.version>
 
     <!-- Test Dependencies -->
     <bouncycastle.version>1.85</bouncycastle.version>
@@ -61,7 +61,7 @@
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <checkstyle.version>11.1.0</checkstyle.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.16.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
@@ -72,7 +72,7 @@
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-    <spotless-maven-plugin.version>3.10.1</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.10.2</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Updates

### Dependencies
- `org.slf4j:slf4j-api` / `org.slf4j:slf4j-simple`: `2.0.18` -> `2.0.19` via `slf4j.version`

### Plugins
- `org.apache.maven.plugins:maven-compiler-plugin`: `3.15.0` -> `3.16.0` via `maven-compiler-plugin.version`
- `com.diffplug.spotless:spotless-maven-plugin`: `3.10.1` -> `3.10.2` via `spotless-maven-plugin.version`

## Skipped

### Prerelease/non-stable suggestions
- None reported.

### Resolution-incompatible candidate
- `org.bouncycastle:bcprov-jdk18on`: `1.85` -> `1.85.2` was reported, but not applied because the shared `bouncycastle.version` property also controls `org.bouncycastle:bcpkix-jdk18on`, and `bcpkix-jdk18on:1.85.2` was not available in Maven Central during verification.

## Verification

- `mvn versions:display-dependency-updates` - passed
- `mvn versions:display-plugin-updates` - passed
- `mvn -q -DskipTests install` - initially failed with Bouncy Castle `1.85.2`, passed after reverting that specific update
- `mvn dependency:resolve` - passed
- `mvn -q spotless:apply` - passed
- `mvn -q clean compile` - passed
- `mvn -q clean verify` - passed

Review: APPROVED by automation review subagent.